### PR TITLE
Fixes initial entropy hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hex-conservative"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +613,7 @@ dependencies = [
  "argon2",
  "bip39",
  "bs58",
+ "hex",
  "hmac",
  "ibig",
  "iris-ztd",

--- a/crates/iris-crypto/Cargo.toml
+++ b/crates/iris-crypto/Cargo.toml
@@ -13,3 +13,6 @@ hmac = "0.12"
 sha2 = "0.10"
 bs58 = { version = "0.5", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+hex = "0.4"

--- a/crates/iris-crypto/src/lib.rs
+++ b/crates/iris-crypto/src/lib.rs
@@ -10,17 +10,78 @@ use bip39::Mnemonic;
 /// Generate master key from entropy and salt using Argon2 + BIP39 + SLIP-10
 pub fn gen_master_key(entropy: &[u8], salt: &[u8]) -> (String, ExtendedKey) {
     let mut argon_output = [0u8; 32];
-    Argon2::new(
-        Algorithm::Argon2d,
-        Version::V0x13,
-        Params::new(6 << 17, 6, 4, None).unwrap(),
+    let params = Params::new(
+        786_432,  // m_cost: 768 MiB in KiB
+        6,        // t_cost: 6 iterations
+        4,        // p_cost: 4 threads
+        Some(32), // output length
     )
-    .hash_password_into(entropy, salt, &mut argon_output)
-    .expect("Invalid entropy and/or salt");
+    .expect("Invalid Argon2 parameters");
+
+    Argon2::new(Algorithm::Argon2d, Version::V0x13, params)
+        .hash_password_into(entropy, salt, &mut argon_output)
+        .expect("Invalid entropy and/or salt");
+
+    argon_output.reverse();
 
     let mnemonic = Mnemonic::from_entropy(&argon_output).unwrap();
     (
         mnemonic.to_string(),
         derive_master_key(&mnemonic.to_seed("")),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use ibig::UBig;
+    use iris_ztd::Hashable;
+
+    use super::*;
+
+    fn parse_byts_decimal(wid: usize, decimal: &str) -> Vec<u8> {
+        let cleaned: String = decimal.chars().filter(|c| c.is_ascii_digit()).collect();
+        let n = UBig::from_str_radix(&cleaned, 10).expect("Invalid decimal value");
+        let bytes_be = n.to_be_bytes();
+        let mut res = vec![0u8; wid];
+        let mut started = false;
+        let mut idx = 0;
+        for byte in bytes_be.iter() {
+            if *byte != 0 || started {
+                started = true;
+                if idx < wid {
+                    res[idx] = *byte;
+                    idx += 1;
+                }
+            }
+        }
+        res
+    }
+
+    #[test]
+    fn test_keygen() {
+        const LOG_ENTROPY_DEC: &str =
+            "31944036134313954129336387727597658952065175074761089084822804536972439767490";
+        const LOG_SALT_DEC: &str = "143851195137845551434793173733272547792";
+        const LOG_MNEMONIC: &str = "pass destroy hub reject cricket flight camp garden scale liquid increase pool miracle fly tower file door cage vault tone night zero push crime";
+
+        let entropy = parse_byts_decimal(32, LOG_ENTROPY_DEC);
+        let salt = parse_byts_decimal(16, LOG_SALT_DEC);
+
+        let (mnemonic, keypair) = gen_master_key(&entropy, &salt);
+        assert_eq!(mnemonic, LOG_MNEMONIC);
+
+        // check private key, chain code and pkh
+        assert_eq!(
+            hex::encode(keypair.private_key.unwrap().to_be_bytes()),
+            "362b4073814e43f427983a83f11efcceb6741082c18f0d64b7e47340ba4485ba"
+        );
+        assert_eq!(
+            hex::encode(keypair.chain_code),
+            "95b522320f4dfae7486155b9529c582af3d7898ece606a802c43415786ced8d9"
+        );
+        assert_eq!(
+            keypair.public_key.hash().to_string(),
+            "AyzPiJoqcqmdZdjxZ9aGLnVsbYcCphidHERKBWVXyKhNqTirshTmicG"
+        );
+    }
 }


### PR DESCRIPTION
Fixes a small mismatch between the hood wallet and our implementation.
The hash bytes need to be reversed before generating the seed. This ensures our implementation generates the same seedphrase given the same entropy.

Additionally, this adds an end-to-end test.