### PR TITLE
Disable default arrayvec features

### DIFF
--- a/.github/workflows/nostd-build.yaml
+++ b/.github/workflows/nostd-build.yaml
@@ -1,0 +1,32 @@
+name: no_std Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@1.91.0
+      with:
+        targets: wasm32-unknown-unknown
+
+    - name: Check iris-ztd no-alloc
+      run: cargo check -p iris-ztd --no-default-features --target wasm32-unknown-unknown
+
+    - name: Check iris-ztd alloc
+      run: cargo check -p iris-ztd --no-default-features --features alloc --target wasm32-unknown-unknown
+
+    - name: Check iris-crypto alloc
+      run: cargo check -p iris-crypto --no-default-features --features alloc --target wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,5 @@ ibig = { version = "0.3", default-features = false, features = ["num-traits"] }
 crypto-bigint = { version = "0.6", default-features = false, features = ["serde"] }
 serdect = { version = "0.3", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+arrayvec = { version = "0.7", default-features = false }
+

--- a/crates/iris-crypto/Cargo.toml
+++ b/crates/iris-crypto/Cargo.toml
@@ -21,7 +21,7 @@ hmac = { version = "0.12", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 bs58 = { version = "0.5", default-features = false, features = [] }
 serde = { workspace = true }
-arrayvec = "0.7"
+arrayvec = { workspace = true }
 tsify = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 crypto-bigint.workspace = true

--- a/crates/iris-ztd/Cargo.toml
+++ b/crates/iris-ztd/Cargo.toml
@@ -20,10 +20,10 @@ arrayref = "0.3"
 num-traits = { version = "0.2", default-features = false }
 serde = { workspace = true }
 iris-ztd-derive = { workspace = true }
-arrayvec = "0.7"
+arrayvec = { workspace = true }
 tsify = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
-either = { version = "1", default_features = false }
+either = { version = "1", default-features = false }
 
 [dev-dependencies]
 serde_json = { version = "1", default-features = false, features = ["alloc"] }

--- a/crates/iris-ztd/src/fixed.rs
+++ b/crates/iris-ztd/src/fixed.rs
@@ -1,4 +1,6 @@
-use crate::{Digest, Hashable, Noun, NounDecode, NounEncode};
+use crate::{Digest, Hashable};
+#[cfg(feature = "alloc")]
+use crate::{Noun, NounDecode, NounEncode};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 macro_rules! fixed_noun {
@@ -44,12 +46,14 @@ macro_rules! fixed_noun {
             }
         }
 
+        #[cfg(feature = "alloc")]
         impl<const V: $t> NounEncode for $n<V> {
             fn to_noun(&self) -> Noun {
                 V.to_noun()
             }
         }
 
+        #[cfg(feature = "alloc")]
         impl<const V: $t> NounDecode for $n<V> {
             fn from_noun(noun: &Noun) -> Option<Self> {
                 let v: $d = NounDecode::from_noun(noun)?;
@@ -164,12 +168,14 @@ impl<'de, const V: u64> Deserialize<'de> for FixedTas<V> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<const V: u64> NounEncode for FixedTas<V> {
     fn to_noun(&self) -> Noun {
         V.to_noun()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<const V: u64> NounDecode for FixedTas<V> {
     fn from_noun(noun: &Noun) -> Option<Self> {
         let v: u64 = NounDecode::from_noun(noun)?;


### PR DESCRIPTION
Disables default features in arrayvec not required for nostd builds.

Additionally, no-alloc builds are fixed and a CI step is added to check for future regressions regarding no-std and no-alloc compilation.