### PR TITLE
Fix/belts to atom parity

### DIFF
--- a/crates/iris-wasm/src/noun.rs
+++ b/crates/iris-wasm/src/noun.rs
@@ -1,4 +1,4 @@
-use iris_ztd::{cue as cue_internal, jam as jam_internal, Belt, Noun, NounDecode, NounEncode};
+use iris_ztd::{cue as cue_internal, jam as jam_internal, BeltSeq, Noun, NounDecode, NounEncode};
 use wasm_bindgen::prelude::*;
 
 /// Cue a jammed Uint8Array into a Noun (see `jam`).
@@ -47,7 +47,7 @@ pub fn tas_belts(s: &str) -> Noun {
 #[wasm_bindgen(js_name = "atomToBelts")]
 pub fn atom_to_belts(atom: Noun) -> Result<Noun, JsValue> {
     match atom {
-        Noun::Atom(atom) => Ok((&iris_ztd::belts_from_ubig(atom)[..]).to_noun()),
+        Noun::Atom(atom) => Ok(BeltSeq(iris_ztd::belts_from_ubig(atom)).to_noun()),
         _ => Err(JsValue::from_str("not an atom")),
     }
 }
@@ -55,10 +55,49 @@ pub fn atom_to_belts(atom: Noun) -> Result<Noun, JsValue> {
 /// Convert a sequence of belts back into one atom.
 #[wasm_bindgen(js_name = "beltsToAtom")]
 pub fn belts_to_atom(noun: Noun) -> Result<Noun, JsValue> {
-    // Append tail so that this is parsed as list
-    // TODO: don't do this
-    let noun = Noun::Cell(noun.into(), 0u64.to_noun().into());
-    let belts: Vec<Belt> =
+    let BeltSeq(belts) =
         NounDecode::from_noun(&noun).ok_or_else(|| JsValue::from_str("unable to parse belts"))?;
     Ok(Noun::Atom(iris_ztd::belts_to_ubig(&belts)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iris_ztd::Belt;
+
+    #[test]
+    fn atom_belts_round_trip_single_belt_atom() {
+        let atom = tas("bridge");
+        let belts = atom_to_belts(atom.clone()).unwrap();
+        let round_trip = belts_to_atom(belts).unwrap();
+
+        assert_eq!(round_trip, atom);
+    }
+
+    #[test]
+    fn bridge_metadata_round_trips_through_belts() {
+        let metadata = "base:84532:0x742d35Cc6634C0532925a3b844Bc454e4438f44e";
+        let belts = atom_to_belts(tas(metadata)).unwrap();
+        let round_trip = belts_to_atom(belts).unwrap();
+
+        assert_eq!(untas(round_trip).unwrap(), metadata);
+    }
+
+    #[test]
+    fn base_address_round_trips_through_belts() {
+        let address = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e";
+        let belts = atom_to_belts(tas(address)).unwrap();
+        let round_trip = belts_to_atom(belts).unwrap();
+
+        assert_eq!(untas(round_trip).unwrap(), address);
+    }
+
+    #[test]
+    fn belts_to_atom_accepts_improper_belt_sequence() {
+        let noun = Noun::Cell(Belt(7).to_noun().into(), Belt(9).to_noun().into());
+        let atom = belts_to_atom(noun).unwrap();
+        let expected = iris_ztd::belts_to_ubig(&[Belt(7), Belt(9)]);
+
+        assert_eq!(atom, Noun::Atom(expected));
+    }
 }

--- a/crates/iris-ztd/src/hash.rs
+++ b/crates/iris-ztd/src/hash.rs
@@ -50,8 +50,10 @@ pub fn belts_to_bytes(belts: &[Belt]) -> Vec<u8> {
 pub fn belts_to_ubig(belts: &[Belt]) -> UBig {
     let p = UBig::from(PRIME);
     let mut num = UBig::from(0u64);
+    let mut power = UBig::from(1u64);
     for belt in belts {
-        num = num * &p + UBig::from(belt.0);
+        num += UBig::from(belt.0) * &power;
+        power *= &p;
     }
     num
 }
@@ -855,5 +857,14 @@ mod tests {
             vec.hash().to_string(),
             "5F6UZhcWYBDSJ3CvevfiABhdSjc9qNh29KcH5rs8FJB4NNPHRn3oqQJ"
         );
+    }
+
+    #[test]
+    fn belts_and_ubig_round_trip_multi_belt_atom() {
+        let atom = UBig::from(PRIME) * UBig::from(9u64) + UBig::from(7u64);
+        let belts = belts_from_ubig(atom.clone());
+
+        assert_eq!(belts, vec![Belt(7), Belt(9)]);
+        assert_eq!(belts_to_ubig(&belts), atom);
     }
 }

--- a/crates/iris-ztd/src/noun.rs
+++ b/crates/iris-ztd/src/noun.rs
@@ -574,6 +574,44 @@ impl<T: NounEncode> NounEncode for Vec<T> {
     }
 }
 
+/// A belt sequence encoded as an improper noun list, without a trailing `~`.
+#[repr(transparent)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BeltSeq(pub Vec<Belt>);
+
+impl NounEncode for BeltSeq {
+    fn to_noun(&self) -> Noun {
+        match self.0.split_last() {
+            None => atom(0),
+            Some((last, rest)) => {
+                let mut acc = last.to_noun();
+                for item in rest.iter().rev() {
+                    acc = cons(item.to_noun(), acc);
+                }
+                acc
+            }
+        }
+    }
+}
+
+impl NounDecode for BeltSeq {
+    fn from_noun(mut noun: &Noun) -> Option<Self> {
+        let mut ret = vec![];
+        loop {
+            match noun {
+                Noun::Cell(a, b) => {
+                    ret.push(Belt::from_noun(a)?);
+                    noun = b;
+                }
+                noun => {
+                    ret.push(Belt::from_noun(noun)?);
+                    return Some(Self(ret));
+                }
+            }
+        }
+    }
+}
+
 impl<T: NounDecode> NounDecode for Vec<T> {
     fn from_noun(mut noun: &Noun) -> Option<Self> {
         let mut ret = vec![];
@@ -613,6 +651,31 @@ impl NounDecode for String {
             return None;
         };
         String::from_utf8(a.to_le_bytes()).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    fn belt_seq_encodes_without_list_terminator() {
+        let noun = BeltSeq(vec![Belt(7), Belt(9)]).to_noun();
+
+        let Noun::Cell(head, tail) = &noun else {
+            panic!("expected cell");
+        };
+        assert_eq!(Belt::from_noun(head).unwrap(), Belt(7));
+        assert_eq!(Belt::from_noun(tail).unwrap(), Belt(9));
+    }
+
+    #[test]
+    fn belt_seq_decodes_without_list_terminator() {
+        let noun = cons(Belt(7).to_noun(), Belt(9).to_noun());
+        let BeltSeq(belts) = BeltSeq::from_noun(&noun).unwrap();
+
+        assert_eq!(belts, vec![Belt(7), Belt(9)]);
     }
 }
 

--- a/crates/iris-ztd/src/noun.rs
+++ b/crates/iris-ztd/src/noun.rs
@@ -654,31 +654,6 @@ impl NounDecode for String {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloc::vec;
-
-    #[test]
-    fn belt_seq_encodes_without_list_terminator() {
-        let noun = BeltSeq(vec![Belt(7), Belt(9)]).to_noun();
-
-        let Noun::Cell(head, tail) = &noun else {
-            panic!("expected cell");
-        };
-        assert_eq!(Belt::from_noun(head).unwrap(), Belt(7));
-        assert_eq!(Belt::from_noun(tail).unwrap(), Belt(9));
-    }
-
-    #[test]
-    fn belt_seq_decodes_without_list_terminator() {
-        let noun = cons(Belt(7).to_noun(), Belt(9).to_noun());
-        let BeltSeq(belts) = BeltSeq::from_noun(&noun).unwrap();
-
-        assert_eq!(belts, vec![Belt(7), Belt(9)]);
-    }
-}
-
 /// Jam a noun into bytes vec
 pub fn jam(noun: Noun) -> Vec<u8> {
     fn met0_u64_to_usize(value: u64) -> usize {
@@ -1084,5 +1059,30 @@ impl BitWriter {
             self.flush_acc();
         }
         self.buf
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    fn belt_seq_encodes_without_list_terminator() {
+        let noun = BeltSeq(vec![Belt(7), Belt(9)]).to_noun();
+
+        let Noun::Cell(head, tail) = &noun else {
+            panic!("expected cell");
+        };
+        assert_eq!(Belt::from_noun(head).unwrap(), Belt(7));
+        assert_eq!(Belt::from_noun(tail).unwrap(), Belt(9));
+    }
+
+    #[test]
+    fn belt_seq_decodes_without_list_terminator() {
+        let noun = cons(Belt(7).to_noun(), Belt(9).to_noun());
+        let BeltSeq(belts) = BeltSeq::from_noun(&noun).unwrap();
+
+        assert_eq!(belts, vec![Belt(7), Belt(9)]);
     }
 }


### PR DESCRIPTION
- added `BeltSeq` wrapper struct with custom encoding/decoding according to the spec
- modified `belts_to_ubig` to preserve the order
- added a couple of tests
- ran fmt/clippy on modified modules, CI fails due to problems outside of the scope of the PR