### PR TITLE
Add iris-ffi: native uniffi bindings, API-parallel to iris-wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,12 +354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,17 +405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,15 +449,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
 
 [[package]]
 name = "fs-err"
@@ -582,11 +556,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -747,22 +719,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki-roots",
-]
-
-[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,7 +737,6 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
- "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -789,9 +744,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "ipnet",
  "libc",
- "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.1",
  "tokio",
@@ -808,108 +761,6 @@ dependencies = [
  "cfg-if",
  "num-traits",
  "static_assertions",
-]
-
-[[package]]
-name = "icu_collections"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
-
-[[package]]
-name = "icu_properties"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
-
-[[package]]
-name = "icu_provider"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
 ]
 
 [[package]]
@@ -931,12 +782,6 @@ dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iris-crypto"
@@ -971,12 +816,11 @@ dependencies = [
  "iris-grpc-proto",
  "iris-nockchain-types",
  "iris-ztd",
- "prost",
- "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
+ "tonic",
  "uniffi",
 ]
 
@@ -1110,22 +954,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
-name = "litemap"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
-
-[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchit"
@@ -1200,7 +1032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1257,15 +1089,6 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "potential_utf"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
-dependencies = [
- "zerovec",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -1357,61 +1180,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2 0.6.1",
- "thiserror 2.0.17",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.4",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.17",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2 0.6.1",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,18 +1207,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1460,17 +1218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -1480,15 +1228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1519,44 +1258,6 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower 0.5.2",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
 
 [[package]]
 name = "ring"
@@ -1597,6 +1298,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1606,12 +1308,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -1723,18 +1433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serdect"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,12 +1504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,20 +1531,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "tap"
@@ -1920,16 +1598,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -2067,13 +1735,16 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2126,7 +1797,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",
@@ -2145,27 +1816,8 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
- "tokio",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "pin-project-lite",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "url",
 ]
 
 [[package]]
@@ -2390,24 +2042,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2519,13 +2153,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
+name = "webpki-roots"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2724,41 +2357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
-name = "writeable"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "yoke"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -2782,61 +2386,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-
-[[package]]
-name = "zerotrie"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "askama"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow",
+]
+
+[[package]]
+name = "async-compat"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ba85bc55464dcbf728b56d97e119d673f4cf9062be330a9a26f3acf504a590"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +207,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bip39"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,10 +306,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -299,6 +411,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +450,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +466,24 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "funty"
@@ -435,9 +582,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -457,6 +606,17 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -587,6 +747,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +781,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -612,7 +789,9 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.1",
  "tokio",
@@ -629,6 +808,108 @@ dependencies = [
  "cfg-if",
  "num-traits",
  "static_assertions",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -652,6 +933,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "iris-crypto"
 version = "0.2.0"
 dependencies = [
@@ -671,6 +958,26 @@ dependencies = [
  "sha2",
  "tsify",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "iris-ffi"
+version = "0.2.0"
+dependencies = [
+ "bip39",
+ "hex",
+ "ibig",
+ "iris-crypto",
+ "iris-grpc-proto",
+ "iris-nockchain-types",
+ "iris-ztd",
+ "prost",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "uniffi",
 ]
 
 [[package]]
@@ -803,10 +1110,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchit"
@@ -827,6 +1146,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +1167,16 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num-traits"
@@ -865,7 +1200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -916,6 +1251,21 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1007,6 +1357,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.1",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.1",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,8 +1439,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1045,7 +1460,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1055,6 +1480,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1087,6 +1521,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.2",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1592,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1637,36 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -1166,6 +1723,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serdect"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1756,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,6 +1778,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
@@ -1217,6 +1804,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1246,6 +1839,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tap"
@@ -1264,6 +1871,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
 ]
 
 [[package]]
@@ -1304,6 +1920,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1348,6 +1974,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +2005,15 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1481,7 +2126,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -1500,8 +2145,27 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
+ "tokio",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -1598,6 +2262,150 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "uniffi"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3291800a6b06569f7d3e15bdb6dc235e0f0c8bd3eb07177f430057feb076415f"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "uniffi_bindgen",
+ "uniffi_core",
+ "uniffi_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04b99fa7796eaaa7b87976a0dbdd1178dc1ee702ea00aca2642003aef9b669e"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "indexmap 2.12.0",
+ "once_cell",
+ "serde",
+ "tempfile",
+ "textwrap",
+ "toml",
+ "uniffi_internal_macros",
+ "uniffi_meta",
+ "uniffi_pipeline",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38a9a27529ccff732f8efddb831b65b1e07f7dea3fd4cacd4a35a8c4b253b98"
+dependencies = [
+ "anyhow",
+ "async-compat",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09acd2ce09c777dd65ee97c251d33c8a972afc04873f1e3b21eb3492ade16933"
+dependencies = [
+ "anyhow",
+ "indexmap 2.12.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5596f178c4f7aafa1a501c4e0b96236a96bc2ef92bdb453d83e609dad0040152"
+dependencies = [
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beadc1f460eb2e209263c49c4f5b19e9a02e00a3b2b393f78ad10d766346ecff"
+dependencies = [
+ "anyhow",
+ "siphasher",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd76b3ac8a2d964ca9fce7df21c755afb4c77b054a85ad7a029ad179cc5abb8a"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.12.0",
+ "tempfile",
+ "uniffi_internal_macros",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319cf905911d70d5b97ce0f46f101619a22e9a189c8c46d797a9955e9233716"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "weedle2",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "version_check"
@@ -1708,6 +2516,34 @@ checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1888,12 +2724,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -1910,6 +2775,66 @@ name = "zerocopy-derive"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/iris-grpc-proto",
   "crates/iris-wasm",
   "crates/iris-ztd-derive",
+  "crates/iris-ffi",
 ]
 
 resolver = "2"

--- a/crates/iris-ffi/Cargo.toml
+++ b/crates/iris-ffi/Cargo.toml
@@ -24,10 +24,9 @@ bip39 = { version = "2.0", default-features = false, features = ["alloc", "std"]
 serde = { workspace = true }
 serde_json = "1"
 thiserror = "2.0"
-prost = "0.13"
+tonic = { version = "0.12", default-features = false }
 uniffi = { version = "0.29", features = ["tokio"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 [dev-dependencies]
 hex = "0.4"

--- a/crates/iris-ffi/Cargo.toml
+++ b/crates/iris-ffi/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "iris-ffi"
+version.workspace = true
+edition.workspace = true
+keywords = ["nockchain", "iris", "wallet", "nock"]
+license = "MIT"
+repository = "https://github.com/nockbox/iris-rs"
+rust-version = "1.88.0"
+description = "Native (uniffi) bindings for Iris wallet — API-parallel to iris-wasm"
+homepage = "https://nockbox.org"
+authors = ["NockBox inc. <tech@nockbox.org>"]
+
+[lib]
+crate-type = ["lib", "staticlib", "cdylib"]
+name = "iris_ffi"
+
+[dependencies]
+iris-crypto = { workspace = true, features = ["default"] }
+iris-nockchain-types = { workspace = true }
+iris-ztd = { workspace = true, features = ["default"] }
+iris-grpc-proto = { workspace = true }
+ibig = { workspace = true }
+bip39 = { version = "2.0", default-features = false, features = ["alloc", "std"] }
+serde = { workspace = true }
+serde_json = "1"
+thiserror = "2.0"
+prost = "0.13"
+uniffi = { version = "0.29", features = ["tokio"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+
+[dev-dependencies]
+hex = "0.4"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/iris-ffi/README.md
+++ b/crates/iris-ffi/README.md
@@ -51,3 +51,36 @@ parity gate (MOBILE_STRATEGY.md §6 R1/R3).
 
 Keep this crate's surface in lockstep with `iris-wasm`: any PR changing
 `crates/iris-wasm`'s exports should change `iris-ffi` in the same PR.
+
+## React Native stack safety
+
+Hermes invokes UBRN exports **synchronously on a small (~512 KiB) pthread
+stack**. Cheetah curve ops, SLIP-10 derivation, Noun hashing, and tx
+building can overflow that guard region in release/TestFlight builds (SIGBUS
+at stack guard).
+
+All stack-sensitive exports delegate through `crypto_stack::run_on_crypto_stack`
+(4 MiB scoped thread). When adding new FFI exports that touch crypto or tx
+engine code, wrap them through that helper — do not run heavy work inline on
+the JS thread.
+
+High-risk patterns to always wrap:
+
+- `PrivateKey::public_key`, `PrivateKey::sign`, `ExtendedKey::derive_child`
+- `Hashable::hash`, `NounEncode` / `NounDecode`, `Belt` → Noun → hash
+- `TxBuilder::{simple_spend, recalc_and_set_fee, sign, validate, build}`
+- Raw tx projection / protobuf conversion
+
+## TestFlight release (iris-mobile)
+
+After changing `iris-ffi`:
+
+1. Commit/push the Rust fix in `iris-rs` (the generated `.xcframework` is
+   gitignored in iris-mobile).
+2. From `IrisWallet/`, point `modules/iris-core/ubrn.config.yaml` at the
+   patched `iris-rs` worktree and run `npm run ubrn:ios`.
+3. Restore `ubrn.config.yaml` to the canonical `iris-rs` path.
+4. Increment `CURRENT_PROJECT_VERSION` in the Xcode project.
+5. Archive with **Release** configuration and upload to TestFlight.
+6. If a crash occurs, symbolicate against the archive's dSYM:
+   `atos -arch arm64 -o IrisWallet.app.dSYM/Contents/Resources/DWARF/IrisWallet -l <load_addr> <pc>`

--- a/crates/iris-ffi/README.md
+++ b/crates/iris-ffi/README.md
@@ -23,17 +23,11 @@ fulfill the `@nockbox/iris-sdk/wasm` module surface 1:1. Consumed by
 
 ## gRPC transport
 
-`FfiGrpcClient` speaks **gRPC-web unary over HTTPS** (reqwest + rustls) — the
-same protocol the browser extension uses against `https://rpc.nockbox.org`,
-which does not accept plain gRPC. All four public RPCs are unary, so the
-framing is trivial. If infra later exposes a plain-gRPC endpoint, the
-tonic-based `PublicNockchainGrpcClient` in `iris-grpc-proto` (plus a TLS
-feature) can replace the transport without changing this crate's surface.
-
-> Verification note: a live call against `rpc.nockbox.org` could not be run
-> from the development container (egress 403 at the edge). Run
-> `get_balance_by_address` against the public endpoint from a dev machine
-> before relying on the transport.
+`FfiGrpcClient` speaks **plain gRPC over HTTP/2 + TLS** via tonic. Verified
+live (2026-06-12) against both `https://rpc.nockbox.org` (the extension's
+default endpoint — its proxy passes plain gRPC through) and
+`https://nockchain-api.zorp.io` (the upstream). Response JSON shapes are
+identical to the wasm client's (same pb types, serde-serialized).
 
 ## Scope (v0)
 

--- a/crates/iris-ffi/README.md
+++ b/crates/iris-ffi/README.md
@@ -1,0 +1,59 @@
+# iris-ffi
+
+Native (uniffi) bindings for the Iris wallet core — **API-parallel to
+[`iris-wasm`](../iris-wasm)** so the React Native app's TypeScript adapter can
+fulfill the `@nockbox/iris-sdk/wasm` module surface 1:1. Consumed by
+`nockbox/iris-mobile` via
+[uniffi-bindgen-react-native](https://github.com/jhugman/uniffi-bindgen-react-native)
+(see iris-mobile's `docs/MOBILE_STRATEGY.md` §3 for the strategy and the
+2a/2b trade-off analysis).
+
+## Boundary conventions
+
+- The workspace's `tsify` is configured in **JSON mode**, so every complex
+  type already crosses the wasm boundary as serde-JSON. Here the same types
+  cross as **JSON strings**; after `JSON.parse` the JS side sees byte-identical
+  object shapes to the wasm build.
+- `Digest` and `Nicks` cross as bare strings (base58 / decimal), exactly as
+  their tsify branded-string types.
+- Byte buffers cross as `Vec<u8>` ↔ `ArrayBuffer`; scalars natively.
+- Stateful wasm classes (`PrivateKey`, `TxBuilder`, `SpendBuilder`,
+  `GrpcClient`) are uniffi objects. `ExtendedKey` is a plain record; the TS
+  adapter wraps it in a class exposing `deriveChild` for wasm parity.
+
+## gRPC transport
+
+`FfiGrpcClient` speaks **gRPC-web unary over HTTPS** (reqwest + rustls) — the
+same protocol the browser extension uses against `https://rpc.nockbox.org`,
+which does not accept plain gRPC. All four public RPCs are unary, so the
+framing is trivial. If infra later exposes a plain-gRPC endpoint, the
+tonic-based `PublicNockchainGrpcClient` in `iris-grpc-proto` (plus a TLS
+feature) can replace the transport without changing this crate's surface.
+
+> Verification note: a live call against `rpc.nockbox.org` could not be run
+> from the development container (egress 403 at the edge). Run
+> `get_balance_by_address` against the public endpoint from a dev machine
+> before relying on the transport.
+
+## Scope (v0)
+
+Implements the surface actually consumed by the iris extension / iris-mobile
+TS layer (~30 functions + 4 objects), not all of `iris-wasm`'s 277
+macro-generated exports. Known deferred items:
+
+- `TxBuilder.spend(spendBuilder)` / `allSpends()` (object-passing between
+  handles; settle conventions during UBRN integration)
+- peek/poke (`private-api`) — the extension never calls them
+- balance pagination with snapshot-changed retry (wasm client doesn't paginate
+  either; port from `iris-grpc-proto::client` when needed)
+
+## Parity gate
+
+The unit tests pin the same golden vectors as `iris-crypto`'s tests and
+iris-mobile's jest suite (mnemonic → key material → pkh, sign/verify,
+jam/cue, atom↔belts round-trip). The same fixtures must pass against
+`iris-wasm` in Node and `iris-ffi` on device — that is the cross-runtime
+parity gate (MOBILE_STRATEGY.md §6 R1/R3).
+
+Keep this crate's surface in lockstep with `iris-wasm`: any PR changing
+`crates/iris-wasm`'s exports should change `iris-ffi` in the same PR.

--- a/crates/iris-ffi/src/crypto_stack.rs
+++ b/crates/iris-ffi/src/crypto_stack.rs
@@ -1,0 +1,31 @@
+//! Run stack-heavy crypto / tx-engine work off the React Native JS thread.
+//!
+//! Hermes invokes UBRN exports synchronously on a small (~512 KiB) pthread
+//! stack. Cheetah curve ops, SLIP-10 derivation, Noun hashing, and tx
+//! building can overflow that guard region in release/TestFlight builds.
+//! Every such export should delegate through `run_on_crypto_stack`.
+
+use std::thread;
+
+use crate::{FfiError, Result};
+
+/// Stack size for dedicated crypto worker threads (4 MiB).
+pub const CRYPTO_STACK_SIZE: usize = 4 * 1024 * 1024;
+
+/// Execute `f` on a scoped thread with an enlarged stack.
+pub(crate) fn run_on_crypto_stack<T, F>(name: &str, f: F) -> Result<T>
+where
+    T: Send,
+    F: FnOnce() -> T + Send,
+{
+    thread::scope(|scope| {
+        let handle = thread::Builder::new()
+            .name(name.to_string())
+            .stack_size(CRYPTO_STACK_SIZE)
+            .spawn_scoped(scope, f)
+            .map_err(|e| FfiError::msg(format!("Failed to spawn {name} thread: {e}")))?;
+        handle
+            .join()
+            .map_err(|_| FfiError::msg(format!("{name} panicked")))
+    })
+}

--- a/crates/iris-ffi/src/grpc.rs
+++ b/crates/iris-ffi/src/grpc.rs
@@ -1,147 +1,34 @@
 //! gRPC client, mirroring `iris-wasm` `grpc.rs`.
 //!
-//! Transport: **gRPC-web unary over HTTPS** (reqwest + rustls), the same
-//! protocol the browser extension uses against `https://rpc.nockbox.org` —
-//! iris-rs's own docs note the public RPC speaks gRPC-web only, so native
-//! tonic cannot reach it (see iris-grpc-proto's `grpc_balance_fixture`
-//! example). If infra later exposes plain gRPC, the tonic-based
-//! `PublicNockchainGrpcClient` in iris-grpc-proto (plus a TLS feature) can
-//! replace this transport without changing the FFI surface.
-//!
-//! All four public RPCs are unary, so the framing is simple:
-//! request body = `0x00 + u32_be(len) + protobuf`, response body = data
-//! frame(s) + trailers frame (flag bit 0x80) carrying `grpc-status`.
+//! Transport: **plain gRPC over HTTP/2 + TLS (tonic)**. Verified 2026-06-12:
+//! both `https://rpc.nockbox.org` and `https://nockchain-api.zorp.io` accept
+//! native tonic connections (the older "gRPC-web only" note in
+//! iris-grpc-proto's example docs is outdated — the proxy passes plain gRPC
+//! through). This replaces an earlier hand-rolled gRPC-web shim; same FFI
+//! surface, same response JSON shapes as the wasm client.
 
 use iris_grpc_proto::pb::common::v1::{Base58Hash, Base58Pubkey, PageRequest};
 use iris_grpc_proto::pb::common::v2 as pb_common_v2;
+use iris_grpc_proto::pb::public::v2::nockchain_service_client::NockchainServiceClient;
 use iris_grpc_proto::pb::public::v2::*;
-use prost::Message;
 
 use crate::{from_json, to_json, FfiError, Result};
 
-const SERVICE_PATH: &str = "/nockchain.public.v2.NockchainService";
-
-fn frame_request<R: Message>(req: &R) -> Vec<u8> {
-    let payload = req.encode_to_vec();
-    let mut body = Vec::with_capacity(5 + payload.len());
-    body.push(0u8);
-    body.extend_from_slice(&(payload.len() as u32).to_be_bytes());
-    body.extend_from_slice(&payload);
-    body
-}
-
-struct GrpcWebResponse {
-    data: Vec<u8>,
-    grpc_status: Option<i32>,
-    grpc_message: Option<String>,
-}
-
-fn parse_frames(bytes: &[u8]) -> Result<GrpcWebResponse> {
-    let mut data = Vec::new();
-    let mut grpc_status = None;
-    let mut grpc_message = None;
-
-    let mut i = 0usize;
-    while i + 5 <= bytes.len() {
-        let flag = bytes[i];
-        let len = u32::from_be_bytes(
-            bytes[i + 1..i + 5]
-                .try_into()
-                .map_err(|_| FfiError::msg("invalid gRPC-web frame header"))?,
-        ) as usize;
-        if i + 5 + len > bytes.len() {
-            return Err(FfiError::msg("truncated gRPC-web frame"));
-        }
-        let frame = &bytes[i + 5..i + 5 + len];
-        if flag & 0x80 != 0 {
-            // Trailers frame: HTTP/1-style headers
-            for line in String::from_utf8_lossy(frame).lines() {
-                if let Some((name, value)) = line.split_once(':') {
-                    let name = name.trim().to_ascii_lowercase();
-                    let value = value.trim();
-                    if name == "grpc-status" {
-                        grpc_status = value.parse::<i32>().ok();
-                    } else if name == "grpc-message" {
-                        grpc_message = Some(value.to_string());
-                    }
-                }
-            }
-        } else {
-            data.extend_from_slice(frame);
-        }
-        i += 5 + len;
-    }
-
-    Ok(GrpcWebResponse {
-        data,
-        grpc_status,
-        grpc_message,
-    })
-}
-
 /// Mirror of wasm `GrpcClient` — async methods return/accept the same JSON
-/// shapes as the tsify boundary.
+/// shapes as the tsify boundary (pb types, serde-serialized).
 #[derive(uniffi::Object)]
 pub struct FfiGrpcClient {
     endpoint: String,
-    client: reqwest::Client,
 }
 
 impl FfiGrpcClient {
-    async fn unary<Req: Message, Resp: Message + Default>(
-        &self,
-        method: &str,
-        request: &Req,
-    ) -> Result<Resp> {
-        let url = format!("{}{}/{}", self.endpoint, SERVICE_PATH, method);
-        let response = self
-            .client
-            .post(&url)
-            .header("content-type", "application/grpc-web+proto")
-            .header("x-grpc-web", "1")
-            .body(frame_request(request))
-            .send()
+    /// Connect per call, like the wasm client constructs its transport per
+    /// call. tonic channels are cheap to set up and this keeps the handle
+    /// free of interior mutability.
+    async fn client(&self) -> Result<NockchainServiceClient<tonic::transport::Channel>> {
+        NockchainServiceClient::connect(self.endpoint.clone())
             .await
-            .map_err(|e| FfiError::msg(format!("gRPC error: {e}")))?;
-
-        // grpc-status may arrive as response headers (trailers-only replies)
-        let header_status = response
-            .headers()
-            .get("grpc-status")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.parse::<i32>().ok());
-        let header_message = response
-            .headers()
-            .get("grpc-message")
-            .and_then(|v| v.to_str().ok())
-            .map(str::to_string);
-        let http_status = response.status();
-
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|e| FfiError::msg(format!("gRPC error reading body: {e}")))?;
-
-        if !http_status.is_success() {
-            return Err(FfiError::msg(format!(
-                "gRPC error: HTTP {http_status} from {url}"
-            )));
-        }
-
-        let parsed = parse_frames(&bytes)?;
-        let status = parsed.grpc_status.or(header_status).unwrap_or(0);
-        if status != 0 {
-            let message = parsed
-                .grpc_message
-                .or(header_message)
-                .unwrap_or_else(|| "unknown".to_string());
-            return Err(FfiError::msg(format!(
-                "gRPC error: status {status}: {message}"
-            )));
-        }
-
-        Resp::decode(parsed.data.as_slice())
-            .map_err(|e| FfiError::msg(format!("gRPC error decoding response: {e}")))
+            .map_err(|e| FfiError::msg(format!("gRPC error: {e}")))
     }
 
     async fn get_balance(
@@ -157,7 +44,13 @@ impl FfiGrpcClient {
             }),
         };
 
-        let response: WalletGetBalanceResponse = self.unary("WalletGetBalance", &request).await?;
+        let response = self
+            .client()
+            .await?
+            .wallet_get_balance(request)
+            .await
+            .map_err(|e| FfiError::msg(format!("gRPC error: {e}")))?
+            .into_inner();
 
         match response.result {
             Some(wallet_get_balance_response::Result::Balance(balance)) => Ok(balance),
@@ -181,7 +74,6 @@ impl FfiGrpcClient {
         };
         Ok(Self {
             endpoint: normalized.trim_end_matches('/').to_string(),
-            client: reqwest::Client::new(),
         })
     }
 
@@ -213,8 +105,13 @@ impl FfiGrpcClient {
             raw_tx: Some(raw_tx),
         };
 
-        let response: WalletSendTransactionResponse =
-            self.unary("WalletSendTransaction", &request).await?;
+        let response = self
+            .client()
+            .await?
+            .wallet_send_transaction(request)
+            .await
+            .map_err(|e| FfiError::msg(format!("gRPC error: {e}")))?
+            .into_inner();
 
         match response.result {
             Some(wallet_send_transaction_response::Result::Ack(_)) => {
@@ -233,8 +130,13 @@ impl FfiGrpcClient {
             tx_id: Some(Base58Hash { hash: tx_id }),
         };
 
-        let response: TransactionAcceptedResponse =
-            self.unary("TransactionAccepted", &request).await?;
+        let response = self
+            .client()
+            .await?
+            .transaction_accepted(request)
+            .await
+            .map_err(|e| FfiError::msg(format!("gRPC error: {e}")))?
+            .into_inner();
 
         match response.result {
             Some(transaction_accepted_response::Result::Accepted(accepted)) => Ok(accepted),
@@ -249,58 +151,6 @@ impl FfiGrpcClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn frames_a_unary_request() {
-        let request = TransactionAcceptedRequest {
-            tx_id: Some(Base58Hash { hash: "abc".into() }),
-        };
-        let body = frame_request(&request);
-        assert_eq!(body[0], 0);
-        let len = u32::from_be_bytes(body[1..5].try_into().unwrap()) as usize;
-        assert_eq!(len, body.len() - 5);
-        let decoded = TransactionAcceptedRequest::decode(&body[5..]).unwrap();
-        assert_eq!(decoded.tx_id.unwrap().hash, "abc");
-    }
-
-    #[test]
-    fn parses_data_and_trailer_frames() {
-        let payload = TransactionAcceptedResponse {
-            result: Some(transaction_accepted_response::Result::Accepted(true)),
-        }
-        .encode_to_vec();
-
-        let mut body = Vec::new();
-        body.push(0u8);
-        body.extend_from_slice(&(payload.len() as u32).to_be_bytes());
-        body.extend_from_slice(&payload);
-        let trailers = b"grpc-status: 0\r\ngrpc-message: ok";
-        body.push(0x80);
-        body.extend_from_slice(&(trailers.len() as u32).to_be_bytes());
-        body.extend_from_slice(trailers);
-
-        let parsed = parse_frames(&body).unwrap();
-        assert_eq!(parsed.grpc_status, Some(0));
-        assert_eq!(parsed.grpc_message.as_deref(), Some("ok"));
-        let decoded = TransactionAcceptedResponse::decode(parsed.data.as_slice()).unwrap();
-        assert!(matches!(
-            decoded.result,
-            Some(transaction_accepted_response::Result::Accepted(true))
-        ));
-    }
-
-    #[test]
-    fn reports_non_zero_grpc_status() {
-        let trailers = b"grpc-status: 14\r\ngrpc-message: unavailable";
-        let mut body = Vec::new();
-        body.push(0x80);
-        body.extend_from_slice(&(trailers.len() as u32).to_be_bytes());
-        body.extend_from_slice(trailers);
-
-        let parsed = parse_frames(&body).unwrap();
-        assert_eq!(parsed.grpc_status, Some(14));
-        assert_eq!(parsed.grpc_message.as_deref(), Some("unavailable"));
-    }
 
     #[test]
     fn endpoint_normalization() {

--- a/crates/iris-ffi/src/grpc.rs
+++ b/crates/iris-ffi/src/grpc.rs
@@ -1,0 +1,312 @@
+//! gRPC client, mirroring `iris-wasm` `grpc.rs`.
+//!
+//! Transport: **gRPC-web unary over HTTPS** (reqwest + rustls), the same
+//! protocol the browser extension uses against `https://rpc.nockbox.org` —
+//! iris-rs's own docs note the public RPC speaks gRPC-web only, so native
+//! tonic cannot reach it (see iris-grpc-proto's `grpc_balance_fixture`
+//! example). If infra later exposes plain gRPC, the tonic-based
+//! `PublicNockchainGrpcClient` in iris-grpc-proto (plus a TLS feature) can
+//! replace this transport without changing the FFI surface.
+//!
+//! All four public RPCs are unary, so the framing is simple:
+//! request body = `0x00 + u32_be(len) + protobuf`, response body = data
+//! frame(s) + trailers frame (flag bit 0x80) carrying `grpc-status`.
+
+use iris_grpc_proto::pb::common::v1::{Base58Hash, Base58Pubkey, PageRequest};
+use iris_grpc_proto::pb::common::v2 as pb_common_v2;
+use iris_grpc_proto::pb::public::v2::*;
+use prost::Message;
+
+use crate::{from_json, to_json, FfiError, Result};
+
+const SERVICE_PATH: &str = "/nockchain.public.v2.NockchainService";
+
+fn frame_request<R: Message>(req: &R) -> Vec<u8> {
+    let payload = req.encode_to_vec();
+    let mut body = Vec::with_capacity(5 + payload.len());
+    body.push(0u8);
+    body.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    body.extend_from_slice(&payload);
+    body
+}
+
+struct GrpcWebResponse {
+    data: Vec<u8>,
+    grpc_status: Option<i32>,
+    grpc_message: Option<String>,
+}
+
+fn parse_frames(bytes: &[u8]) -> Result<GrpcWebResponse> {
+    let mut data = Vec::new();
+    let mut grpc_status = None;
+    let mut grpc_message = None;
+
+    let mut i = 0usize;
+    while i + 5 <= bytes.len() {
+        let flag = bytes[i];
+        let len = u32::from_be_bytes(
+            bytes[i + 1..i + 5]
+                .try_into()
+                .map_err(|_| FfiError::msg("invalid gRPC-web frame header"))?,
+        ) as usize;
+        if i + 5 + len > bytes.len() {
+            return Err(FfiError::msg("truncated gRPC-web frame"));
+        }
+        let frame = &bytes[i + 5..i + 5 + len];
+        if flag & 0x80 != 0 {
+            // Trailers frame: HTTP/1-style headers
+            for line in String::from_utf8_lossy(frame).lines() {
+                if let Some((name, value)) = line.split_once(':') {
+                    let name = name.trim().to_ascii_lowercase();
+                    let value = value.trim();
+                    if name == "grpc-status" {
+                        grpc_status = value.parse::<i32>().ok();
+                    } else if name == "grpc-message" {
+                        grpc_message = Some(value.to_string());
+                    }
+                }
+            }
+        } else {
+            data.extend_from_slice(frame);
+        }
+        i += 5 + len;
+    }
+
+    Ok(GrpcWebResponse {
+        data,
+        grpc_status,
+        grpc_message,
+    })
+}
+
+/// Mirror of wasm `GrpcClient` — async methods return/accept the same JSON
+/// shapes as the tsify boundary.
+#[derive(uniffi::Object)]
+pub struct FfiGrpcClient {
+    endpoint: String,
+    client: reqwest::Client,
+}
+
+impl FfiGrpcClient {
+    async fn unary<Req: Message, Resp: Message + Default>(
+        &self,
+        method: &str,
+        request: &Req,
+    ) -> Result<Resp> {
+        let url = format!("{}{}/{}", self.endpoint, SERVICE_PATH, method);
+        let response = self
+            .client
+            .post(&url)
+            .header("content-type", "application/grpc-web+proto")
+            .header("x-grpc-web", "1")
+            .body(frame_request(request))
+            .send()
+            .await
+            .map_err(|e| FfiError::msg(format!("gRPC error: {e}")))?;
+
+        // grpc-status may arrive as response headers (trailers-only replies)
+        let header_status = response
+            .headers()
+            .get("grpc-status")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<i32>().ok());
+        let header_message = response
+            .headers()
+            .get("grpc-message")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+        let http_status = response.status();
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| FfiError::msg(format!("gRPC error reading body: {e}")))?;
+
+        if !http_status.is_success() {
+            return Err(FfiError::msg(format!(
+                "gRPC error: HTTP {http_status} from {url}"
+            )));
+        }
+
+        let parsed = parse_frames(&bytes)?;
+        let status = parsed.grpc_status.or(header_status).unwrap_or(0);
+        if status != 0 {
+            let message = parsed
+                .grpc_message
+                .or(header_message)
+                .unwrap_or_else(|| "unknown".to_string());
+            return Err(FfiError::msg(format!(
+                "gRPC error: status {status}: {message}"
+            )));
+        }
+
+        Resp::decode(parsed.data.as_slice())
+            .map_err(|e| FfiError::msg(format!("gRPC error decoding response: {e}")))
+    }
+
+    async fn get_balance(
+        &self,
+        selector: wallet_get_balance_request::Selector,
+    ) -> Result<pb_common_v2::Balance> {
+        let request = WalletGetBalanceRequest {
+            selector: Some(selector),
+            page: Some(PageRequest {
+                client_page_items_limit: 0,
+                page_token: String::new(),
+                max_bytes: 0,
+            }),
+        };
+
+        let response: WalletGetBalanceResponse = self.unary("WalletGetBalance", &request).await?;
+
+        match response.result {
+            Some(wallet_get_balance_response::Result::Balance(balance)) => Ok(balance),
+            Some(wallet_get_balance_response::Result::Error(e)) => {
+                Err(FfiError::msg(format!("Server error: {}", e.message)))
+            }
+            None => Err(FfiError::msg("Empty response from server")),
+        }
+    }
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl FfiGrpcClient {
+    /// wasm: `new GrpcClient(endpoint)`
+    #[uniffi::constructor]
+    pub fn new(endpoint: String) -> Result<Self> {
+        let normalized = if endpoint.contains("://") {
+            endpoint
+        } else {
+            format!("https://{endpoint}")
+        };
+        Ok(Self {
+            endpoint: normalized.trim_end_matches('/').to_string(),
+            client: reqwest::Client::new(),
+        })
+    }
+
+    /// wasm: `grpcClient.getBalanceByAddress(address)` -> Balance JSON
+    pub async fn get_balance_by_address(&self, address: String) -> Result<String> {
+        let balance = self
+            .get_balance(wallet_get_balance_request::Selector::Address(
+                Base58Pubkey { key: address },
+            ))
+            .await?;
+        to_json(&balance)
+    }
+
+    /// wasm: `grpcClient.getBalanceByFirstName(firstName)` -> Balance JSON
+    pub async fn get_balance_by_first_name(&self, first_name: String) -> Result<String> {
+        let balance = self
+            .get_balance(wallet_get_balance_request::Selector::FirstName(
+                Base58Hash { hash: first_name },
+            ))
+            .await?;
+        to_json(&balance)
+    }
+
+    /// wasm: `grpcClient.sendTransaction(rawTxProtobuf)` (pb RawTransaction JSON in)
+    pub async fn send_transaction(&self, raw_tx_pb_json: String) -> Result<String> {
+        let raw_tx: pb_common_v2::RawTransaction = from_json(&raw_tx_pb_json)?;
+        let request = WalletSendTransactionRequest {
+            tx_id: raw_tx.id,
+            raw_tx: Some(raw_tx),
+        };
+
+        let response: WalletSendTransactionResponse =
+            self.unary("WalletSendTransaction", &request).await?;
+
+        match response.result {
+            Some(wallet_send_transaction_response::Result::Ack(_)) => {
+                Ok(String::from("Transaction acknowledged"))
+            }
+            Some(wallet_send_transaction_response::Result::Error(e)) => {
+                Err(FfiError::msg(format!("Server error: {}", e.message)))
+            }
+            None => Err(FfiError::msg("Empty response from server")),
+        }
+    }
+
+    /// wasm: `grpcClient.transactionAccepted(txId)`
+    pub async fn transaction_accepted(&self, tx_id: String) -> Result<bool> {
+        let request = TransactionAcceptedRequest {
+            tx_id: Some(Base58Hash { hash: tx_id }),
+        };
+
+        let response: TransactionAcceptedResponse =
+            self.unary("TransactionAccepted", &request).await?;
+
+        match response.result {
+            Some(transaction_accepted_response::Result::Accepted(accepted)) => Ok(accepted),
+            Some(transaction_accepted_response::Result::Error(e)) => {
+                Err(FfiError::msg(format!("Server error: {}", e.message)))
+            }
+            None => Err(FfiError::msg("Empty response from server")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frames_a_unary_request() {
+        let request = TransactionAcceptedRequest {
+            tx_id: Some(Base58Hash { hash: "abc".into() }),
+        };
+        let body = frame_request(&request);
+        assert_eq!(body[0], 0);
+        let len = u32::from_be_bytes(body[1..5].try_into().unwrap()) as usize;
+        assert_eq!(len, body.len() - 5);
+        let decoded = TransactionAcceptedRequest::decode(&body[5..]).unwrap();
+        assert_eq!(decoded.tx_id.unwrap().hash, "abc");
+    }
+
+    #[test]
+    fn parses_data_and_trailer_frames() {
+        let payload = TransactionAcceptedResponse {
+            result: Some(transaction_accepted_response::Result::Accepted(true)),
+        }
+        .encode_to_vec();
+
+        let mut body = Vec::new();
+        body.push(0u8);
+        body.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        body.extend_from_slice(&payload);
+        let trailers = b"grpc-status: 0\r\ngrpc-message: ok";
+        body.push(0x80);
+        body.extend_from_slice(&(trailers.len() as u32).to_be_bytes());
+        body.extend_from_slice(trailers);
+
+        let parsed = parse_frames(&body).unwrap();
+        assert_eq!(parsed.grpc_status, Some(0));
+        assert_eq!(parsed.grpc_message.as_deref(), Some("ok"));
+        let decoded = TransactionAcceptedResponse::decode(parsed.data.as_slice()).unwrap();
+        assert!(matches!(
+            decoded.result,
+            Some(transaction_accepted_response::Result::Accepted(true))
+        ));
+    }
+
+    #[test]
+    fn reports_non_zero_grpc_status() {
+        let trailers = b"grpc-status: 14\r\ngrpc-message: unavailable";
+        let mut body = Vec::new();
+        body.push(0x80);
+        body.extend_from_slice(&(trailers.len() as u32).to_be_bytes());
+        body.extend_from_slice(trailers);
+
+        let parsed = parse_frames(&body).unwrap();
+        assert_eq!(parsed.grpc_status, Some(14));
+        assert_eq!(parsed.grpc_message.as_deref(), Some("unavailable"));
+    }
+
+    #[test]
+    fn endpoint_normalization() {
+        let client = FfiGrpcClient::new("rpc.nockbox.org".into()).unwrap();
+        assert_eq!(client.endpoint, "https://rpc.nockbox.org");
+        let client = FfiGrpcClient::new("http://127.0.0.1:8080/".into()).unwrap();
+        assert_eq!(client.endpoint, "http://127.0.0.1:8080");
+    }
+}

--- a/crates/iris-ffi/src/lib.rs
+++ b/crates/iris-ffi/src/lib.rs
@@ -10,11 +10,15 @@
 //! serde_json), producing byte-identical object shapes on the JS side after
 //! `JSON.parse`. Scalars and byte buffers cross natively.
 
+mod crypto_stack;
 mod grpc;
 mod tx;
 
+pub use crypto_stack::CRYPTO_STACK_SIZE;
 pub use grpc::*;
 pub use tx::*;
+
+use crypto_stack::run_on_crypto_stack;
 
 use iris_crypto::cheetah::{PrivateKey as CryptoPrivateKey, PublicKey, Signature};
 use iris_crypto::slip10::{derive_master_key as derive_master_key_internal, ExtendedKey};
@@ -125,7 +129,10 @@ impl FfiExtendedKey {
 /// wasm: `deriveMasterKey(seed)`
 #[uniffi::export]
 pub fn derive_master_key(seed: Vec<u8>) -> FfiExtendedKey {
-    FfiExtendedKey::from_internal(&derive_master_key_internal(&seed))
+    run_on_crypto_stack("iris-derive-master", || {
+        FfiExtendedKey::from_internal(&derive_master_key_internal(&seed))
+    })
+    .expect("master key derivation failed")
 }
 
 /// wasm: `deriveMasterKeyFromMnemonic(mnemonic, passphrase?)`
@@ -144,13 +151,7 @@ pub fn derive_master_key_from_mnemonic(
 #[uniffi::export]
 pub fn derive_child(key: FfiExtendedKey, index: u32) -> Result<FfiExtendedKey> {
     let internal = key.to_internal()?;
-    let child = std::thread::Builder::new()
-        .name("iris-derive-child".to_string())
-        .stack_size(4 * 1024 * 1024)
-        .spawn(move || internal.derive_child(index))
-        .map_err(|e| FfiError::msg(format!("Failed to spawn derivation thread: {e}")))?
-        .join()
-        .map_err(|_| FfiError::msg("Child key derivation panicked"))?;
+    let child = run_on_crypto_stack("iris-derive-child", move || internal.derive_child(index))?;
     Ok(FfiExtendedKey::from_internal(&child))
 }
 
@@ -160,8 +161,10 @@ pub fn hash_public_key(public_key_bytes: Vec<u8>) -> Result<String> {
     if public_key_bytes.len() != 97 {
         return Err(FfiError::msg("Public key must be 97 bytes"));
     }
-    let public_key = PublicKey::from_be_bytes(&public_key_bytes);
-    Ok(digest_to_string(&public_key.hash()))
+    run_on_crypto_stack("iris-hash-pubkey", move || {
+        let public_key = PublicKey::from_be_bytes(&public_key_bytes);
+        digest_to_string(&public_key.hash())
+    })
 }
 
 /// wasm: `publicKeyFromHex(hex)` -> PublicKey JSON (or None)
@@ -187,9 +190,11 @@ pub fn sign_message(private_key_bytes: Vec<u8>, message: String) -> Result<Strin
     if private_key_bytes.len() != 32 {
         return Err(FfiError::msg("Private key must be 32 bytes"));
     }
-    let private_key = CryptoPrivateKey(U256::from_be_slice(&private_key_bytes));
-    let digest = Belt::from_bytes(message.as_bytes()).to_noun().hash();
-    to_json(&private_key.sign(&digest))
+    run_on_crypto_stack("iris-sign-message", move || {
+        let private_key = CryptoPrivateKey(U256::from_be_slice(&private_key_bytes));
+        let digest = Belt::from_bytes(message.as_bytes()).to_noun().hash();
+        to_json(&private_key.sign(&digest))
+    })?
 }
 
 /// wasm: `verifySignature(publicKeyBytes, signature, message)`
@@ -203,10 +208,12 @@ pub fn verify_signature(
     if public_key_bytes.len() != 97 {
         return Err(FfiError::msg("Public key must be 97 bytes"));
     }
-    let public_key = PublicKey::from_be_bytes(&public_key_bytes);
     let signature: Signature = from_json(&signature_json)?;
-    let digest = Belt::from_bytes(message.as_bytes()).to_noun().hash();
-    Ok(public_key.verify(&digest, &signature))
+    run_on_crypto_stack("iris-verify-signature", move || {
+        let public_key = PublicKey::from_be_bytes(&public_key_bytes);
+        let digest = Belt::from_bytes(message.as_bytes()).to_noun().hash();
+        public_key.verify(&digest, &signature)
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -250,21 +257,23 @@ pub fn untas(noun_json: String) -> Result<String> {
 #[uniffi::export]
 pub fn atom_to_belts(noun_json: String) -> Result<String> {
     let noun: iris_ztd::Noun = from_json(&noun_json)?;
-    match noun {
+    run_on_crypto_stack("iris-atom-to-belts", move || match noun {
         iris_ztd::Noun::Atom(atom) => {
             to_json(&iris_ztd::BeltSeq(iris_ztd::belts_from_ubig(atom)).to_noun())
         }
         _ => Err(FfiError::msg("not an atom")),
-    }
+    })?
 }
 
 /// wasm: `beltsToAtom(noun)` -> Noun JSON
 #[uniffi::export]
 pub fn belts_to_atom(noun_json: String) -> Result<String> {
     let noun: iris_ztd::Noun = from_json(&noun_json)?;
-    let iris_ztd::BeltSeq(belts) =
-        NounDecode::from_noun(&noun).ok_or_else(|| FfiError::msg("unable to parse belts"))?;
-    to_json(&iris_ztd::Noun::Atom(iris_ztd::belts_to_ubig(&belts)))
+    run_on_crypto_stack("iris-belts-to-atom", move || {
+        let iris_ztd::BeltSeq(belts) =
+            NounDecode::from_noun(&noun).ok_or_else(|| FfiError::msg("unable to parse belts"))?;
+        to_json(&iris_ztd::Noun::Atom(iris_ztd::belts_to_ubig(&belts)))
+    })?
 }
 
 // ---------------------------------------------------------------------------
@@ -276,21 +285,21 @@ pub fn belts_to_atom(noun_json: String) -> Result<String> {
 #[uniffi::export]
 pub fn lock_hash(lock_json: String) -> Result<String> {
     let lock: Lock = from_json(&lock_json)?;
-    Ok(digest_to_string(&lock.hash()))
+    run_on_crypto_stack("iris-lock-hash", move || digest_to_string(&lock.hash()))
 }
 
 /// wasm: `lockRootHash(lockRoot)` -> Digest
 #[uniffi::export]
 pub fn lock_root_hash(lock_root_json: String) -> Result<String> {
     let lock_root: LockRoot = from_json(&lock_root_json)?;
-    Ok(digest_to_string(&lock_root.hash()))
+    run_on_crypto_stack("iris-lock-root-hash", move || digest_to_string(&lock_root.hash()))
 }
 
 /// wasm: `noteHash(note)` -> Digest
 #[uniffi::export]
 pub fn note_hash(note_json: String) -> Result<String> {
     let note: Note = from_json(&note_json)?;
-    Ok(digest_to_string(&note.hash()))
+    run_on_crypto_stack("iris-note-hash", move || digest_to_string(&note.hash()))
 }
 
 /// wasm: `pkhNew(m, hashes)` -> Pkh JSON
@@ -320,14 +329,16 @@ pub fn spend_condition_new_pkh(pkh_json: String) -> Result<String> {
 #[uniffi::export]
 pub fn spend_condition_hash(spend_condition_json: String) -> Result<String> {
     let sc: SpendCondition = from_json(&spend_condition_json)?;
-    Ok(digest_to_string(&sc.hash()))
+    run_on_crypto_stack("iris-spend-condition-hash", move || digest_to_string(&sc.hash()))
 }
 
 /// wasm: `spendConditionFirstName(sc)` -> Digest
 #[uniffi::export]
 pub fn spend_condition_first_name(spend_condition_json: String) -> Result<String> {
     let sc: SpendCondition = from_json(&spend_condition_json)?;
-    Ok(digest_to_string(&sc.first_name()))
+    run_on_crypto_stack("iris-spend-condition-first-name", move || {
+        digest_to_string(&sc.first_name())
+    })
 }
 
 /// wasm: `noteToProtobuf(note)` -> PbCom2Note JSON
@@ -366,8 +377,10 @@ pub fn spend_condition_from_protobuf(pb_json: String) -> Result<String> {
 #[uniffi::export]
 pub fn raw_tx_to_protobuf(raw_tx_v1_json: String) -> Result<String> {
     let tx: RawTxV1 = from_json(&raw_tx_v1_json)?;
-    let pb: iris_grpc_proto::pb::common::v2::RawTransaction = tx.into();
-    to_json(&pb)
+    run_on_crypto_stack("iris-raw-tx-to-protobuf", move || {
+        let pb: iris_grpc_proto::pb::common::v2::RawTransaction = tx.into();
+        to_json(&pb)
+    })?
 }
 
 /// wasm: `rawTxFromProtobuf(pb)` -> RawTx JSON
@@ -382,7 +395,7 @@ pub fn raw_tx_from_protobuf(pb_json: String) -> Result<String> {
 #[uniffi::export]
 pub fn nockchain_tx_to_raw_tx(nockchain_tx_json: String) -> Result<String> {
     let tx: NockchainTx = from_json(&nockchain_tx_json)?;
-    to_json(&tx.to_raw_tx())
+    run_on_crypto_stack("iris-nockchain-tx-to-raw", move || to_json(&tx.to_raw_tx()))?
 }
 
 /// wasm: `rawTxV1ToNockchainTx(tx)` -> NockchainTx JSON
@@ -401,7 +414,9 @@ pub fn raw_tx_outputs(
 ) -> Result<String> {
     let tx: RawTx = from_json(&raw_tx_json)?;
     let settings: TxEngineSettings = from_json(&tx_engine_settings_json)?;
-    to_json(&tx.outputs(block_height, settings))
+    run_on_crypto_stack("iris-raw-tx-outputs", move || {
+        to_json(&tx.outputs(block_height, settings))
+    })?
 }
 
 /// wasm: `rawTxV1Outputs(tx, originPage, settings)` -> NoteV1[] JSON
@@ -413,7 +428,9 @@ pub fn raw_tx_v1_outputs(
 ) -> Result<String> {
     let tx: RawTxV1 = from_json(&raw_tx_v1_json)?;
     let settings: TxEngineSettings = from_json(&tx_engine_settings_json)?;
-    to_json(&tx.outputs(origin_page, settings))
+    run_on_crypto_stack("iris-raw-tx-v1-outputs", move || {
+        to_json(&tx.outputs(origin_page, settings))
+    })?
 }
 
 /// wasm: `txEngineSettingsV1Default()` -> TxEngineSettings JSON

--- a/crates/iris-ffi/src/lib.rs
+++ b/crates/iris-ffi/src/lib.rs
@@ -144,7 +144,14 @@ pub fn derive_master_key_from_mnemonic(
 #[uniffi::export]
 pub fn derive_child(key: FfiExtendedKey, index: u32) -> Result<FfiExtendedKey> {
     let internal = key.to_internal()?;
-    Ok(FfiExtendedKey::from_internal(&internal.derive_child(index)))
+    let child = std::thread::Builder::new()
+        .name("iris-derive-child".to_string())
+        .stack_size(4 * 1024 * 1024)
+        .spawn(move || internal.derive_child(index))
+        .map_err(|e| FfiError::msg(format!("Failed to spawn derivation thread: {e}")))?
+        .join()
+        .map_err(|_| FfiError::msg("Child key derivation panicked"))?;
+    Ok(FfiExtendedKey::from_internal(&child))
 }
 
 /// wasm: `hashPublicKey(bytes)` -> Digest (base58 string)

--- a/crates/iris-ffi/src/lib.rs
+++ b/crates/iris-ffi/src/lib.rs
@@ -1,0 +1,552 @@
+//! Native (uniffi) bindings for the Iris wallet core.
+//!
+//! API-parallel to `iris-wasm`: every export mirrors a `@nockbox/iris-wasm`
+//! export by name and behavior so the TypeScript adapter on React Native can
+//! fulfill the `@nockbox/iris-sdk/wasm` module surface 1:1.
+//!
+//! Boundary convention: the workspace's tsify is configured in JSON mode, so
+//! every complex type already crosses the wasm boundary as serde-JSON. Here
+//! the same types cross as **JSON strings** (parsed/serialized with
+//! serde_json), producing byte-identical object shapes on the JS side after
+//! `JSON.parse`. Scalars and byte buffers cross natively.
+
+mod grpc;
+mod tx;
+
+pub use grpc::*;
+pub use tx::*;
+
+use iris_crypto::cheetah::{PrivateKey as CryptoPrivateKey, PublicKey, Signature};
+use iris_crypto::slip10::{derive_master_key as derive_master_key_internal, ExtendedKey};
+use iris_nockchain_types::v1::{Lock, LockRoot, NockchainTx, Pkh, RawTxV1, SpendCondition};
+use iris_nockchain_types::{note::Note, tx::RawTx, TxEngineSettings};
+use iris_ztd::{Digest, Hashable, NounDecode, NounEncode, U256};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+uniffi::setup_scaffolding!();
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum FfiError {
+    #[error("{message}")]
+    Ffi { message: String },
+}
+
+impl FfiError {
+    pub fn msg(message: impl Into<String>) -> Self {
+        FfiError::Ffi {
+            message: message.into(),
+        }
+    }
+}
+
+impl From<serde_json::Error> for FfiError {
+    fn from(e: serde_json::Error) -> Self {
+        FfiError::msg(format!("JSON error: {e}"))
+    }
+}
+
+pub type Result<T> = std::result::Result<T, FfiError>;
+
+// ---------------------------------------------------------------------------
+// JSON boundary helpers
+// ---------------------------------------------------------------------------
+
+pub(crate) fn from_json<T: DeserializeOwned>(s: &str) -> Result<T> {
+    Ok(serde_json::from_str(s)?)
+}
+
+pub(crate) fn to_json<T: Serialize>(v: &T) -> Result<String> {
+    Ok(serde_json::to_string(v)?)
+}
+
+/// Digests cross the wasm boundary as bare base58 strings (tsify type
+/// `string`); accept/produce the same here.
+pub(crate) fn digest_from_str(s: &str) -> Result<Digest> {
+    serde_json::from_value(serde_json::Value::String(s.to_string()))
+        .map_err(|e| FfiError::msg(format!("invalid digest '{s}': {e}")))
+}
+
+pub(crate) fn digest_to_string(d: &Digest) -> String {
+    d.to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Key derivation (mirrors iris-wasm crypto.rs)
+// ---------------------------------------------------------------------------
+
+/// Mirror of wasm `ExtendedKey` (a data record on this side; the TS adapter
+/// wraps it in a class exposing `deriveChild`).
+#[derive(uniffi::Record)]
+pub struct FfiExtendedKey {
+    pub private_key: Option<Vec<u8>>,
+    pub public_key: Vec<u8>,
+    pub chain_code: Vec<u8>,
+}
+
+impl FfiExtendedKey {
+    fn from_internal(key: &ExtendedKey) -> Self {
+        FfiExtendedKey {
+            private_key: key.private_key.as_ref().map(|pk| pk.to_be_bytes().to_vec()),
+            public_key: key.public_key.to_be_bytes().to_vec(),
+            chain_code: key.chain_code.to_vec(),
+        }
+    }
+
+    fn to_internal(&self) -> Result<ExtendedKey> {
+        let private_key = if let Some(pk_bytes) = &self.private_key {
+            if pk_bytes.len() != 32 {
+                return Err(FfiError::msg("Private key must be 32 bytes"));
+            }
+            Some(CryptoPrivateKey(U256::from_be_slice(pk_bytes)))
+        } else {
+            None
+        };
+
+        if self.public_key.len() != 97 {
+            return Err(FfiError::msg("Public key must be 97 bytes"));
+        }
+        let public_key = PublicKey::from_be_bytes(&self.public_key);
+
+        if self.chain_code.len() != 32 {
+            return Err(FfiError::msg("Chain code must be 32 bytes"));
+        }
+        let mut chain_code = [0u8; 32];
+        chain_code.copy_from_slice(&self.chain_code);
+
+        Ok(ExtendedKey {
+            private_key,
+            public_key,
+            chain_code,
+        })
+    }
+}
+
+/// wasm: `deriveMasterKey(seed)`
+#[uniffi::export]
+pub fn derive_master_key(seed: Vec<u8>) -> FfiExtendedKey {
+    FfiExtendedKey::from_internal(&derive_master_key_internal(&seed))
+}
+
+/// wasm: `deriveMasterKeyFromMnemonic(mnemonic, passphrase?)`
+#[uniffi::export]
+pub fn derive_master_key_from_mnemonic(
+    mnemonic: String,
+    passphrase: Option<String>,
+) -> Result<FfiExtendedKey> {
+    let mnemonic = bip39::Mnemonic::parse(&mnemonic)
+        .map_err(|e| FfiError::msg(format!("Invalid mnemonic: {e}")))?;
+    let seed = mnemonic.to_seed(passphrase.as_deref().unwrap_or(""));
+    Ok(derive_master_key(seed.to_vec()))
+}
+
+/// wasm: `ExtendedKey.deriveChild(index)`
+#[uniffi::export]
+pub fn derive_child(key: FfiExtendedKey, index: u32) -> Result<FfiExtendedKey> {
+    let internal = key.to_internal()?;
+    Ok(FfiExtendedKey::from_internal(&internal.derive_child(index)))
+}
+
+/// wasm: `hashPublicKey(bytes)` -> Digest (base58 string)
+#[uniffi::export]
+pub fn hash_public_key(public_key_bytes: Vec<u8>) -> Result<String> {
+    if public_key_bytes.len() != 97 {
+        return Err(FfiError::msg("Public key must be 97 bytes"));
+    }
+    let public_key = PublicKey::from_be_bytes(&public_key_bytes);
+    Ok(digest_to_string(&public_key.hash()))
+}
+
+/// wasm: `publicKeyFromHex(hex)` -> PublicKey JSON (or None)
+#[uniffi::export]
+pub fn public_key_from_hex(hex: String) -> Result<Option<String>> {
+    match PublicKey::from_hex(&hex) {
+        Some(pk) => Ok(Some(to_json(&pk)?)),
+        None => Ok(None),
+    }
+}
+
+/// wasm: `publicKeyToBeBytesVec(publicKey)` (PublicKey JSON in)
+#[uniffi::export]
+pub fn public_key_to_be_bytes_vec(public_key_json: String) -> Result<Vec<u8>> {
+    let pk: PublicKey = from_json(&public_key_json)?;
+    Ok(pk.to_be_bytes().to_vec())
+}
+
+/// wasm: `signMessage(privateKeyBytes, message)` -> Signature JSON
+#[uniffi::export]
+pub fn sign_message(private_key_bytes: Vec<u8>, message: String) -> Result<String> {
+    use iris_ztd::Belt;
+    if private_key_bytes.len() != 32 {
+        return Err(FfiError::msg("Private key must be 32 bytes"));
+    }
+    let private_key = CryptoPrivateKey(U256::from_be_slice(&private_key_bytes));
+    let digest = Belt::from_bytes(message.as_bytes()).to_noun().hash();
+    to_json(&private_key.sign(&digest))
+}
+
+/// wasm: `verifySignature(publicKeyBytes, signature, message)`
+#[uniffi::export]
+pub fn verify_signature(
+    public_key_bytes: Vec<u8>,
+    signature_json: String,
+    message: String,
+) -> Result<bool> {
+    use iris_ztd::Belt;
+    if public_key_bytes.len() != 97 {
+        return Err(FfiError::msg("Public key must be 97 bytes"));
+    }
+    let public_key = PublicKey::from_be_bytes(&public_key_bytes);
+    let signature: Signature = from_json(&signature_json)?;
+    let digest = Belt::from_bytes(message.as_bytes()).to_noun().hash();
+    Ok(public_key.verify(&digest, &signature))
+}
+
+// ---------------------------------------------------------------------------
+// Noun utilities (mirrors iris-wasm noun.rs; Noun crosses as JSON)
+// ---------------------------------------------------------------------------
+
+/// wasm: `cue(bytes)` -> Noun JSON
+#[uniffi::export]
+pub fn cue(jam_bytes: Vec<u8>) -> Result<String> {
+    let noun = iris_ztd::cue(&jam_bytes).ok_or_else(|| FfiError::msg("unable to parse jam"))?;
+    to_json(&noun)
+}
+
+/// wasm: `jam(noun)` (Noun JSON in)
+#[uniffi::export]
+pub fn jam(noun_json: String) -> Result<Vec<u8>> {
+    let noun: iris_ztd::Noun = from_json(&noun_json)?;
+    Ok(iris_ztd::jam(noun))
+}
+
+/// wasm: `tas(string)` -> Noun JSON (atom)
+#[uniffi::export]
+pub fn tas(s: String) -> Result<String> {
+    let a = ibig::UBig::from_le_bytes(s.as_bytes());
+    to_json(&iris_ztd::Noun::Atom(a))
+}
+
+/// wasm: `untas(noun)` -> string
+#[uniffi::export]
+pub fn untas(noun_json: String) -> Result<String> {
+    let noun: iris_ztd::Noun = from_json(&noun_json)?;
+    match noun {
+        iris_ztd::Noun::Atom(atom) => {
+            String::from_utf8(atom.to_le_bytes()).map_err(|_| FfiError::msg("not valid utf8"))
+        }
+        _ => Err(FfiError::msg("not an atom")),
+    }
+}
+
+/// wasm: `atomToBelts(noun)` -> Noun JSON
+#[uniffi::export]
+pub fn atom_to_belts(noun_json: String) -> Result<String> {
+    let noun: iris_ztd::Noun = from_json(&noun_json)?;
+    match noun {
+        iris_ztd::Noun::Atom(atom) => {
+            to_json(&iris_ztd::BeltSeq(iris_ztd::belts_from_ubig(atom)).to_noun())
+        }
+        _ => Err(FfiError::msg("not an atom")),
+    }
+}
+
+/// wasm: `beltsToAtom(noun)` -> Noun JSON
+#[uniffi::export]
+pub fn belts_to_atom(noun_json: String) -> Result<String> {
+    let noun: iris_ztd::Noun = from_json(&noun_json)?;
+    let iris_ztd::BeltSeq(belts) =
+        NounDecode::from_noun(&noun).ok_or_else(|| FfiError::msg("unable to parse belts"))?;
+    to_json(&iris_ztd::Noun::Atom(iris_ztd::belts_to_ubig(&belts)))
+}
+
+// ---------------------------------------------------------------------------
+// Type helpers used by the extension TS layer (lock/spend-condition/note/tx).
+// In iris-wasm these are macro-generated exports; here they are explicit.
+// ---------------------------------------------------------------------------
+
+/// wasm: `lockHash(lock)` -> Digest
+#[uniffi::export]
+pub fn lock_hash(lock_json: String) -> Result<String> {
+    let lock: Lock = from_json(&lock_json)?;
+    Ok(digest_to_string(&lock.hash()))
+}
+
+/// wasm: `lockRootHash(lockRoot)` -> Digest
+#[uniffi::export]
+pub fn lock_root_hash(lock_root_json: String) -> Result<String> {
+    let lock_root: LockRoot = from_json(&lock_root_json)?;
+    Ok(digest_to_string(&lock_root.hash()))
+}
+
+/// wasm: `noteHash(note)` -> Digest
+#[uniffi::export]
+pub fn note_hash(note_json: String) -> Result<String> {
+    let note: Note = from_json(&note_json)?;
+    Ok(digest_to_string(&note.hash()))
+}
+
+/// wasm: `pkhNew(m, hashes)` -> Pkh JSON
+#[uniffi::export]
+pub fn pkh_new(m: u64, hashes: Vec<String>) -> Result<String> {
+    let digests = hashes
+        .iter()
+        .map(|h| digest_from_str(h))
+        .collect::<Result<Vec<Digest>>>()?;
+    to_json(&Pkh::new(m, digests))
+}
+
+/// wasm: `pkhSingle(hash)` -> Pkh JSON
+#[uniffi::export]
+pub fn pkh_single(hash: String) -> Result<String> {
+    to_json(&Pkh::single(digest_from_str(&hash)?))
+}
+
+/// wasm: `spendConditionNewPkh(pkh)` -> SpendCondition JSON
+#[uniffi::export]
+pub fn spend_condition_new_pkh(pkh_json: String) -> Result<String> {
+    let pkh: Pkh = from_json(&pkh_json)?;
+    to_json(&SpendCondition::new_pkh(pkh))
+}
+
+/// wasm: `spendConditionHash(sc)` -> Digest
+#[uniffi::export]
+pub fn spend_condition_hash(spend_condition_json: String) -> Result<String> {
+    let sc: SpendCondition = from_json(&spend_condition_json)?;
+    Ok(digest_to_string(&sc.hash()))
+}
+
+/// wasm: `spendConditionFirstName(sc)` -> Digest
+#[uniffi::export]
+pub fn spend_condition_first_name(spend_condition_json: String) -> Result<String> {
+    let sc: SpendCondition = from_json(&spend_condition_json)?;
+    Ok(digest_to_string(&sc.first_name()))
+}
+
+/// wasm: `noteToProtobuf(note)` -> PbCom2Note JSON
+#[uniffi::export]
+pub fn note_to_protobuf(note_json: String) -> Result<String> {
+    let note: Note = from_json(&note_json)?;
+    let pb: iris_grpc_proto::pb::common::v2::Note = note.into();
+    to_json(&pb)
+}
+
+/// wasm: `noteFromProtobuf(pbNote)` -> Note JSON
+#[uniffi::export]
+pub fn note_from_protobuf(pb_note_json: String) -> Result<String> {
+    let pb: iris_grpc_proto::pb::common::v2::Note = from_json(&pb_note_json)?;
+    let note: Note = pb.try_into().map_err(|e| FfiError::msg(format!("{e}")))?;
+    to_json(&note)
+}
+
+/// wasm: `spendConditionToProtobuf(sc)` -> pb SpendCondition JSON
+#[uniffi::export]
+pub fn spend_condition_to_protobuf(spend_condition_json: String) -> Result<String> {
+    let sc: SpendCondition = from_json(&spend_condition_json)?;
+    let pb: iris_grpc_proto::pb::common::v2::SpendCondition = sc.into();
+    to_json(&pb)
+}
+
+/// wasm: `spendConditionFromProtobuf(pb)` -> SpendCondition JSON
+#[uniffi::export]
+pub fn spend_condition_from_protobuf(pb_json: String) -> Result<String> {
+    let pb: iris_grpc_proto::pb::common::v2::SpendCondition = from_json(&pb_json)?;
+    let sc: SpendCondition = pb.try_into().map_err(|e| FfiError::msg(format!("{e}")))?;
+    to_json(&sc)
+}
+
+/// wasm: `rawTxToProtobuf(rawTxV1)` -> pb RawTransaction JSON
+#[uniffi::export]
+pub fn raw_tx_to_protobuf(raw_tx_v1_json: String) -> Result<String> {
+    let tx: RawTxV1 = from_json(&raw_tx_v1_json)?;
+    let pb: iris_grpc_proto::pb::common::v2::RawTransaction = tx.into();
+    to_json(&pb)
+}
+
+/// wasm: `rawTxFromProtobuf(pb)` -> RawTx JSON
+#[uniffi::export]
+pub fn raw_tx_from_protobuf(pb_json: String) -> Result<String> {
+    let pb: iris_grpc_proto::pb::common::v2::RawTransaction = from_json(&pb_json)?;
+    let tx: RawTx = pb.try_into().map_err(|e| FfiError::msg(format!("{e}")))?;
+    to_json(&tx)
+}
+
+/// wasm: `nockchainTxToRawTx(tx)` -> RawTxV1 JSON
+#[uniffi::export]
+pub fn nockchain_tx_to_raw_tx(nockchain_tx_json: String) -> Result<String> {
+    let tx: NockchainTx = from_json(&nockchain_tx_json)?;
+    to_json(&tx.to_raw_tx())
+}
+
+/// wasm: `rawTxV1ToNockchainTx(tx)` -> NockchainTx JSON
+#[uniffi::export]
+pub fn raw_tx_v1_to_nockchain_tx(raw_tx_v1_json: String) -> Result<String> {
+    let tx: RawTxV1 = from_json(&raw_tx_v1_json)?;
+    to_json(&tx.to_nockchain_tx())
+}
+
+/// wasm: `rawTxOutputs(tx, blockHeight, settings)` -> Note[] JSON
+#[uniffi::export]
+pub fn raw_tx_outputs(
+    raw_tx_json: String,
+    block_height: u32,
+    tx_engine_settings_json: String,
+) -> Result<String> {
+    let tx: RawTx = from_json(&raw_tx_json)?;
+    let settings: TxEngineSettings = from_json(&tx_engine_settings_json)?;
+    to_json(&tx.outputs(block_height, settings))
+}
+
+/// wasm: `rawTxV1Outputs(tx, originPage, settings)` -> NoteV1[] JSON
+#[uniffi::export]
+pub fn raw_tx_v1_outputs(
+    raw_tx_v1_json: String,
+    origin_page: u32,
+    tx_engine_settings_json: String,
+) -> Result<String> {
+    let tx: RawTxV1 = from_json(&raw_tx_v1_json)?;
+    let settings: TxEngineSettings = from_json(&tx_engine_settings_json)?;
+    to_json(&tx.outputs(origin_page, settings))
+}
+
+/// wasm: `txEngineSettingsV1Default()` -> TxEngineSettings JSON
+#[uniffi::export]
+pub fn tx_engine_settings_v1_default() -> Result<String> {
+    to_json(&TxEngineSettings::v1_default())
+}
+
+/// wasm: `txEngineSettingsV1BythosDefault()` -> TxEngineSettings JSON
+#[uniffi::export]
+pub fn tx_engine_settings_v1_bythos_default() -> Result<String> {
+    to_json(&TxEngineSettings::v1_bythos_default())
+}
+
+/// wasm: `digestToProtobuf(digest)` -> pb Hash JSON
+#[uniffi::export]
+pub fn digest_to_protobuf(digest: String) -> Result<String> {
+    let d = digest_from_str(&digest)?;
+    let pb: iris_grpc_proto::pb::common::v1::Hash = d.into();
+    to_json(&pb)
+}
+
+/// wasm: `digestFromProtobuf(pbHash)` -> Digest (base58 string)
+#[uniffi::export]
+pub fn digest_from_protobuf(pb_hash_json: String) -> Result<String> {
+    let pb: iris_grpc_proto::pb::common::v1::Hash = from_json(&pb_hash_json)?;
+    let d: Digest = pb.try_into().map_err(|e| FfiError::msg(format!("{e:?}")))?;
+    Ok(digest_to_string(&d))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Golden vectors from crates/iris-crypto tests (same as the iris-mobile
+    // jest suite — the FFI-parity gate).
+    const GOLDEN_MNEMONIC: &str = "pass destroy hub reject cricket flight camp garden scale liquid increase pool miracle fly tower file door cage vault tone night zero push crime";
+    const GOLDEN_PKH: &str = "AyzPiJoqcqmdZdjxZ9aGLnVsbYcCphidHERKBWVXyKhNqTirshTmicG";
+    const GOLDEN_PRIVATE_KEY_HEX: &str =
+        "362b4073814e43f427983a83f11efcceb6741082c18f0d64b7e47340ba4485ba";
+    const GOLDEN_CHAIN_CODE_HEX: &str =
+        "95b522320f4dfae7486155b9529c582af3d7898ece606a802c43415786ced8d9";
+    const LEDGER_SEED_HEX: &str = "781FB0E232257AE8F9471884436EBC5617E33BF9B8316C35E489052917D40055575003F3D82B18415AE90D24A70FCDE604FF27AD0D8E0FFDF10EF0C41447516D";
+    const LEDGER_PKH: &str = "4EUr383qLuCEzejdmCigFhrsoDkHG2crGxBBFhR35zjVfzn5QdhazGb";
+
+    #[test]
+    fn golden_master_key_from_mnemonic() {
+        let key = derive_master_key_from_mnemonic(GOLDEN_MNEMONIC.into(), None).unwrap();
+        assert_eq!(
+            hex::encode(key.private_key.as_ref().unwrap()),
+            GOLDEN_PRIVATE_KEY_HEX
+        );
+        assert_eq!(hex::encode(&key.chain_code), GOLDEN_CHAIN_CODE_HEX);
+        assert_eq!(hash_public_key(key.public_key).unwrap(), GOLDEN_PKH);
+    }
+
+    #[test]
+    fn golden_master_key_from_seed() {
+        let key = derive_master_key(hex::decode(LEDGER_SEED_HEX).unwrap());
+        assert_eq!(hash_public_key(key.public_key).unwrap(), LEDGER_PKH);
+    }
+
+    #[test]
+    fn derive_child_is_deterministic_and_distinct() {
+        let master = derive_master_key_from_mnemonic(GOLDEN_MNEMONIC.into(), None).unwrap();
+        let clone = derive_master_key_from_mnemonic(GOLDEN_MNEMONIC.into(), None).unwrap();
+        let child1 = derive_child(master, 1).unwrap();
+        let child1b = derive_child(clone, 1).unwrap();
+        assert_eq!(child1.public_key, child1b.public_key);
+        assert_ne!(
+            hash_public_key(child1.public_key.clone()).unwrap(),
+            GOLDEN_PKH
+        );
+    }
+
+    #[test]
+    fn sign_verify_round_trip() {
+        let key = derive_master_key_from_mnemonic(GOLDEN_MNEMONIC.into(), None).unwrap();
+        let signature =
+            sign_message(key.private_key.clone().unwrap(), "hello nockchain".into()).unwrap();
+        assert!(verify_signature(
+            key.public_key.clone(),
+            signature.clone(),
+            "hello nockchain".into()
+        )
+        .unwrap());
+        assert!(!verify_signature(key.public_key.clone(), signature, "tampered".into()).unwrap());
+    }
+
+    #[test]
+    fn tas_untas_round_trip() {
+        let metadata = "base:84532:0x742d35Cc6634C0532925a3b844Bc454e4438f44e";
+        let noun = tas(metadata.into()).unwrap();
+        assert_eq!(untas(noun).unwrap(), metadata);
+    }
+
+    #[test]
+    fn atom_belts_round_trip_through_json_boundary() {
+        // This is the round-trip that is broken in published iris-wasm 0.2.0
+        // (fixed on main, d3a8806). The FFI must keep it working.
+        let metadata = "base:84532:0x742d35Cc6634C0532925a3b844Bc454e4438f44e";
+        let atom = tas(metadata.into()).unwrap();
+        let belts = atom_to_belts(atom.clone()).unwrap();
+        let back = belts_to_atom(belts).unwrap();
+        assert_eq!(untas(back).unwrap(), metadata);
+    }
+
+    #[test]
+    fn jam_cue_round_trip() {
+        let noun = tas("hello".into()).unwrap();
+        let jammed = jam(noun.clone()).unwrap();
+        let cued = cue(jammed).unwrap();
+        assert_eq!(cued, noun);
+    }
+
+    #[test]
+    fn pkh_and_spend_condition_first_name() {
+        let pkh = pkh_single(GOLDEN_PKH.into()).unwrap();
+        let sc = spend_condition_new_pkh(pkh).unwrap();
+        // first_name and hash must be valid digests (base58 strings)
+        let first = spend_condition_first_name(sc.clone()).unwrap();
+        let hash = spend_condition_hash(sc).unwrap();
+        assert!(digest_from_str(&first).is_ok());
+        assert!(digest_from_str(&hash).is_ok());
+    }
+
+    #[test]
+    fn tx_engine_settings_shapes() {
+        let v1: serde_json::Value =
+            serde_json::from_str(&tx_engine_settings_v1_default().unwrap()).unwrap();
+        assert_eq!(v1["tx_engine_version"], 1);
+        let bythos: serde_json::Value =
+            serde_json::from_str(&tx_engine_settings_v1_bythos_default().unwrap()).unwrap();
+        assert_eq!(bythos["tx_engine_patch"], 1);
+    }
+
+    #[test]
+    fn digest_protobuf_round_trip() {
+        let pb = digest_to_protobuf(GOLDEN_PKH.into()).unwrap();
+        let back = digest_from_protobuf(pb).unwrap();
+        assert_eq!(back, GOLDEN_PKH);
+    }
+}

--- a/crates/iris-ffi/src/tx.rs
+++ b/crates/iris-ffi/src/tx.rs
@@ -17,7 +17,7 @@ use iris_nockchain_types::{
 use iris_ztd::U256;
 use serde::Deserialize;
 
-use crate::{digest_from_str, from_json, to_json, FfiError, Result};
+use crate::{crypto_stack::run_on_crypto_stack, digest_from_str, from_json, to_json, FfiError, Result};
 
 fn nicks_from_str(s: &str) -> Result<Nicks> {
     serde_json::from_value(serde_json::Value::String(s.to_string()))
@@ -71,11 +71,13 @@ impl FfiPrivateKey {
         if signing_key_bytes.len() != 32 {
             return Err(FfiError::msg("Private key must be 32 bytes"));
         }
-        let signing_key = CryptoPrivateKey(U256::from_be_slice(&signing_key_bytes));
-        let public_key_bytes = signing_key.public_key().to_be_bytes().to_vec();
-        Ok(Self {
-            signing_key,
-            public_key_bytes,
+        run_on_crypto_stack("iris-private-key-from-bytes", move || {
+            let signing_key = CryptoPrivateKey(U256::from_be_slice(&signing_key_bytes));
+            let public_key_bytes = signing_key.public_key().to_be_bytes().to_vec();
+            Self {
+                signing_key,
+                public_key_bytes,
+            }
         })
     }
 
@@ -162,25 +164,27 @@ impl FfiTxBuilder {
             .map(|(n, lck)| (n, lck.into_tuple()))
             .collect();
 
-        let mut builder = self.builder.lock().unwrap();
-        builder
-            .simple_spend_base(
-                internal_notes,
-                recipient,
-                gift,
-                refund_pkh,
-                include_lock_data,
-            )
+        run_on_crypto_stack("iris-tx-simple-spend", || {
+            let mut builder = self.builder.lock().unwrap();
+            builder
+                .simple_spend_base(
+                    internal_notes,
+                    recipient,
+                    gift,
+                    refund_pkh,
+                    include_lock_data,
+                )
+                .map_err(|e| FfiError::msg(format!("{e}")))?;
+
+            if let Some(fee) = fee_override {
+                builder.set_fee_and_balance_refund(fee, false, include_lock_data)
+            } else {
+                builder.recalc_and_set_fee(include_lock_data)
+            }
             .map_err(|e| FfiError::msg(format!("{e}")))?;
 
-        if let Some(fee) = fee_override {
-            builder.set_fee_and_balance_refund(fee, false, include_lock_data)
-        } else {
-            builder.recalc_and_set_fee(include_lock_data)
-        }
-        .map_err(|e| FfiError::msg(format!("{e}")))?;
-
-        Ok(())
+            Ok::<(), FfiError>(())
+        })?
     }
 
     /// wasm: `txBuilder.setFeeAndBalanceRefund(fee, adjustFee, includeLockData)`
@@ -201,12 +205,14 @@ impl FfiTxBuilder {
 
     /// wasm: `txBuilder.recalcAndSetFee(includeLockData)`
     pub fn recalc_and_set_fee(&self, include_lock_data: bool) -> Result<()> {
-        self.builder
-            .lock()
-            .unwrap()
-            .recalc_and_set_fee(include_lock_data)
-            .map_err(|e| FfiError::msg(e.to_string()))?;
-        Ok(())
+        run_on_crypto_stack("iris-tx-recalc-fee", || {
+            self.builder
+                .lock()
+                .unwrap()
+                .recalc_and_set_fee(include_lock_data)
+                .map_err(|e| FfiError::msg(e.to_string()))?;
+            Ok::<(), FfiError>(())
+        })?
     }
 
     /// wasm: `txBuilder.addPreimage(preimageJam)` -> Digest | undefined
@@ -223,18 +229,21 @@ impl FfiTxBuilder {
 
     /// wasm: `txBuilder.sign(privateKey)`
     pub fn sign(&self, signing_key: &FfiPrivateKey) -> Result<()> {
-        self.builder.lock().unwrap().sign(&signing_key.signing_key);
-        Ok(())
+        run_on_crypto_stack("iris-tx-sign", || {
+            self.builder.lock().unwrap().sign(&signing_key.signing_key);
+        })
     }
 
     /// wasm: `txBuilder.validate()`
     pub fn validate(&self) -> Result<()> {
-        self.builder
-            .lock()
-            .unwrap()
-            .validate()
-            .map_err(|e| FfiError::msg(e.to_string()))?;
-        Ok(())
+        run_on_crypto_stack("iris-tx-validate", || {
+            self.builder
+                .lock()
+                .unwrap()
+                .validate()
+                .map_err(|e| FfiError::msg(e.to_string()))?;
+            Ok::<(), FfiError>(())
+        })?
     }
 
     /// wasm: `txBuilder.curFee()` -> Nicks (decimal string)
@@ -249,7 +258,9 @@ impl FfiTxBuilder {
 
     /// wasm: `txBuilder.build()` -> NockchainTx JSON
     pub fn build(&self) -> Result<String> {
-        to_json(&self.builder.lock().unwrap().build())
+        run_on_crypto_stack("iris-tx-build", || {
+            to_json(&self.builder.lock().unwrap().build())
+        })?
     }
 }
 
@@ -344,7 +355,10 @@ impl FfiSpendBuilder {
 
     /// wasm: `spendBuilder.sign(privateKey)` -> bool
     pub fn sign(&self, signing_key: &FfiPrivateKey) -> bool {
-        self.builder.lock().unwrap().sign(&signing_key.signing_key)
+        run_on_crypto_stack("iris-spend-sign", || {
+            self.builder.lock().unwrap().sign(&signing_key.signing_key)
+        })
+        .unwrap_or(false)
     }
 }
 

--- a/crates/iris-ffi/src/tx.rs
+++ b/crates/iris-ffi/src/tx.rs
@@ -1,0 +1,388 @@
+//! Transaction building objects, mirroring `iris-wasm` `tx.rs`.
+//!
+//! `PrivateKey`, `TxBuilder` and `SpendBuilder` are stateful handles (uniffi
+//! objects). Complex parameters/returns cross as JSON strings with the same
+//! serde shapes as the wasm tsify boundary.
+
+use std::sync::Mutex;
+
+use iris_crypto::cheetah::PrivateKey as CryptoPrivateKey;
+use iris_nockchain_types::{
+    builder::TxBuilder as CoreTxBuilder,
+    note::Note,
+    tx::RawTx,
+    v1::{Lock, LockRoot, NockchainTx, SeedV1},
+    Nicks, SpendBuilder as CoreSpendBuilder, TxEngineSettings,
+};
+use iris_ztd::U256;
+use serde::Deserialize;
+
+use crate::{digest_from_str, from_json, to_json, FfiError, Result};
+
+fn nicks_from_str(s: &str) -> Result<Nicks> {
+    serde_json::from_value(serde_json::Value::String(s.to_string()))
+        .map_err(|e| FfiError::msg(format!("invalid Nicks '{s}': {e}")))
+}
+
+fn nicks_to_string(n: &Nicks) -> String {
+    // Nicks serializes as a decimal string (serde_u64_as_string)
+    serde_json::to_value(n)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_string))
+        .unwrap_or_default()
+}
+
+/// Mirror of wasm `TxLock` (untagged: null/None or { lock, lock_sp_index }).
+#[derive(Deserialize)]
+#[serde(untagged)]
+#[allow(clippy::large_enum_variant)] // mirrors iris-wasm's TxLock exactly
+enum TxLock {
+    None,
+    Some { lock: Lock, lock_sp_index: usize },
+}
+
+impl TxLock {
+    fn into_tuple(self) -> Option<(Lock, usize)> {
+        match self {
+            TxLock::None => None,
+            TxLock::Some {
+                lock,
+                lock_sp_index,
+            } => Some((lock, lock_sp_index)),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PrivateKey (wasm: `PrivateKey`)
+// ---------------------------------------------------------------------------
+
+#[derive(uniffi::Object)]
+pub struct FfiPrivateKey {
+    signing_key: CryptoPrivateKey,
+    public_key_bytes: Vec<u8>,
+}
+
+#[uniffi::export]
+impl FfiPrivateKey {
+    /// wasm: `PrivateKey.fromBytes(bytes)` / `new PrivateKey(bytes)`
+    #[uniffi::constructor]
+    pub fn from_bytes(signing_key_bytes: Vec<u8>) -> Result<Self> {
+        if signing_key_bytes.len() != 32 {
+            return Err(FfiError::msg("Private key must be 32 bytes"));
+        }
+        let signing_key = CryptoPrivateKey(U256::from_be_slice(&signing_key_bytes));
+        let public_key_bytes = signing_key.public_key().to_be_bytes().to_vec();
+        Ok(Self {
+            signing_key,
+            public_key_bytes,
+        })
+    }
+
+    /// wasm: `privateKey.publicKey` getter
+    pub fn public_key(&self) -> Vec<u8> {
+        self.public_key_bytes.clone()
+    }
+
+    /// wasm: `privateKey.backendKind()`
+    pub fn backend_kind(&self) -> String {
+        "bytes".to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TxBuilder (wasm: `TxBuilder`)
+// ---------------------------------------------------------------------------
+
+#[derive(uniffi::Object)]
+pub struct FfiTxBuilder {
+    builder: Mutex<CoreTxBuilder>,
+}
+
+#[uniffi::export]
+impl FfiTxBuilder {
+    /// wasm: `new TxBuilder(settings)`
+    #[uniffi::constructor]
+    pub fn new(settings_json: String) -> Result<Self> {
+        let settings: TxEngineSettings = from_json(&settings_json)?;
+        Ok(Self {
+            builder: Mutex::new(CoreTxBuilder::new(settings)),
+        })
+    }
+
+    /// wasm: `TxBuilder.fromRawTx(tx, settings)`
+    #[uniffi::constructor]
+    pub fn from_raw_tx(raw_tx_json: String, settings_json: String) -> Result<Self> {
+        let tx: RawTx = from_json(&raw_tx_json)?;
+        let settings: TxEngineSettings = from_json(&settings_json)?;
+        let builder =
+            CoreTxBuilder::from_raw_tx(tx, settings).map_err(|e| FfiError::msg(e.to_string()))?;
+        Ok(Self {
+            builder: Mutex::new(builder),
+        })
+    }
+
+    /// wasm: `TxBuilder.fromNockchainTx(tx, settings)`
+    #[uniffi::constructor]
+    pub fn from_nockchain_tx(nockchain_tx_json: String, settings_json: String) -> Result<Self> {
+        let tx: NockchainTx = from_json(&nockchain_tx_json)?;
+        let settings: TxEngineSettings = from_json(&settings_json)?;
+        let builder = CoreTxBuilder::from_nockchain_tx(tx, settings)
+            .map_err(|e| FfiError::msg(e.to_string()))?;
+        Ok(Self {
+            builder: Mutex::new(builder),
+        })
+    }
+
+    /// wasm: `txBuilder.simpleSpend(notes, locks, recipient, gift, feeOverride, refundPkh, includeLockData)`
+    #[allow(clippy::too_many_arguments)]
+    pub fn simple_spend(
+        &self,
+        notes_json: String,
+        locks_json: String,
+        recipient: String,
+        gift: String,
+        fee_override: Option<String>,
+        refund_pkh: String,
+        include_lock_data: bool,
+    ) -> Result<()> {
+        let notes: Vec<Note> = from_json(&notes_json)?;
+        let locks: Vec<TxLock> = from_json(&locks_json)?;
+        if notes.len() != locks.len() {
+            return Err(FfiError::msg("notes and locks must have the same length"));
+        }
+        let recipient = digest_from_str(&recipient)?;
+        let gift = nicks_from_str(&gift)?;
+        let refund_pkh = digest_from_str(&refund_pkh)?;
+        let fee_override = fee_override.map(|f| nicks_from_str(&f)).transpose()?;
+
+        let internal_notes: Vec<(Note, Option<(Lock, usize)>)> = notes
+            .into_iter()
+            .zip(locks)
+            .map(|(n, lck)| (n, lck.into_tuple()))
+            .collect();
+
+        let mut builder = self.builder.lock().unwrap();
+        builder
+            .simple_spend_base(
+                internal_notes,
+                recipient,
+                gift,
+                refund_pkh,
+                include_lock_data,
+            )
+            .map_err(|e| FfiError::msg(format!("{e}")))?;
+
+        if let Some(fee) = fee_override {
+            builder.set_fee_and_balance_refund(fee, false, include_lock_data)
+        } else {
+            builder.recalc_and_set_fee(include_lock_data)
+        }
+        .map_err(|e| FfiError::msg(format!("{e}")))?;
+
+        Ok(())
+    }
+
+    /// wasm: `txBuilder.setFeeAndBalanceRefund(fee, adjustFee, includeLockData)`
+    pub fn set_fee_and_balance_refund(
+        &self,
+        fee: String,
+        adjust_fee: bool,
+        include_lock_data: bool,
+    ) -> Result<()> {
+        let fee = nicks_from_str(&fee)?;
+        self.builder
+            .lock()
+            .unwrap()
+            .set_fee_and_balance_refund(fee, adjust_fee, include_lock_data)
+            .map_err(|e| FfiError::msg(e.to_string()))?;
+        Ok(())
+    }
+
+    /// wasm: `txBuilder.recalcAndSetFee(includeLockData)`
+    pub fn recalc_and_set_fee(&self, include_lock_data: bool) -> Result<()> {
+        self.builder
+            .lock()
+            .unwrap()
+            .recalc_and_set_fee(include_lock_data)
+            .map_err(|e| FfiError::msg(e.to_string()))?;
+        Ok(())
+    }
+
+    /// wasm: `txBuilder.addPreimage(preimageJam)` -> Digest | undefined
+    pub fn add_preimage(&self, preimage_jam: Vec<u8>) -> Result<Option<String>> {
+        let preimage = iris_ztd::cue(&preimage_jam)
+            .ok_or_else(|| FfiError::msg("Unable to cue preimage jam"))?;
+        Ok(self
+            .builder
+            .lock()
+            .unwrap()
+            .add_preimage(preimage)
+            .map(|d| d.to_string()))
+    }
+
+    /// wasm: `txBuilder.sign(privateKey)`
+    pub fn sign(&self, signing_key: &FfiPrivateKey) -> Result<()> {
+        self.builder.lock().unwrap().sign(&signing_key.signing_key);
+        Ok(())
+    }
+
+    /// wasm: `txBuilder.validate()`
+    pub fn validate(&self) -> Result<()> {
+        self.builder
+            .lock()
+            .unwrap()
+            .validate()
+            .map_err(|e| FfiError::msg(e.to_string()))?;
+        Ok(())
+    }
+
+    /// wasm: `txBuilder.curFee()` -> Nicks (decimal string)
+    pub fn cur_fee(&self) -> String {
+        nicks_to_string(&self.builder.lock().unwrap().cur_fee())
+    }
+
+    /// wasm: `txBuilder.calcFee()` -> Nicks (decimal string)
+    pub fn calc_fee(&self) -> String {
+        nicks_to_string(&self.builder.lock().unwrap().calc_fee())
+    }
+
+    /// wasm: `txBuilder.build()` -> NockchainTx JSON
+    pub fn build(&self) -> Result<String> {
+        to_json(&self.builder.lock().unwrap().build())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SpendBuilder (wasm: `SpendBuilder`)
+// ---------------------------------------------------------------------------
+
+#[derive(uniffi::Object)]
+pub struct FfiSpendBuilder {
+    builder: Mutex<CoreSpendBuilder>,
+}
+
+#[uniffi::export]
+impl FfiSpendBuilder {
+    /// wasm: `new SpendBuilder(note, lock?, lockSpIndex?, refundLock?)`
+    #[uniffi::constructor]
+    pub fn new(
+        note_json: String,
+        lock_json: Option<String>,
+        lock_sp_index: Option<u64>,
+        refund_lock_json: Option<String>,
+    ) -> Result<Self> {
+        let note: Note = from_json(&note_json)?;
+        let lock: Option<Lock> = lock_json.map(|l| from_json(&l)).transpose()?;
+        let refund_lock: Option<LockRoot> = refund_lock_json.map(|l| from_json(&l)).transpose()?;
+        let builder = CoreSpendBuilder::new(
+            note,
+            lock.zip(lock_sp_index.map(|i| i as usize)),
+            refund_lock,
+        )
+        .map_err(|e| FfiError::msg(e.to_string()))?;
+        Ok(Self {
+            builder: Mutex::new(builder),
+        })
+    }
+
+    /// wasm: `spendBuilder.fee(nicks)`
+    pub fn fee(&self, fee: String) -> Result<()> {
+        self.builder.lock().unwrap().fee(nicks_from_str(&fee)?);
+        Ok(())
+    }
+
+    /// wasm: `spendBuilder.computeRefund(includeLockData)`
+    pub fn compute_refund(&self, include_lock_data: bool) {
+        self.builder
+            .lock()
+            .unwrap()
+            .compute_refund(include_lock_data);
+    }
+
+    /// wasm: `spendBuilder.curRefund()` -> SeedV1 JSON | undefined
+    pub fn cur_refund(&self) -> Result<Option<String>> {
+        match self.builder.lock().unwrap().cur_refund() {
+            Some(seed) => Ok(Some(to_json(seed)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// wasm: `spendBuilder.isBalanced()`
+    pub fn is_balanced(&self) -> bool {
+        self.builder.lock().unwrap().is_balanced()
+    }
+
+    /// wasm: `spendBuilder.seed(seed)`
+    pub fn seed(&self, seed_json: String) -> Result<()> {
+        let seed: SeedV1 = from_json(&seed_json)?;
+        self.builder.lock().unwrap().seed(seed);
+        Ok(())
+    }
+
+    /// wasm: `spendBuilder.invalidateSigs()`
+    pub fn invalidate_sigs(&self) {
+        self.builder.lock().unwrap().invalidate_sigs();
+    }
+
+    /// wasm: `spendBuilder.missingUnlocks()` -> MissingUnlocks[] JSON
+    pub fn missing_unlocks(&self) -> Result<String> {
+        to_json(&self.builder.lock().unwrap().missing_unlocks())
+    }
+
+    /// wasm: `spendBuilder.addPreimage(preimageJam)` -> Digest | undefined
+    pub fn add_preimage(&self, preimage_jam: Vec<u8>) -> Result<Option<String>> {
+        let preimage = iris_ztd::cue(&preimage_jam)
+            .ok_or_else(|| FfiError::msg("Unable to cue preimage jam"))?;
+        Ok(self
+            .builder
+            .lock()
+            .unwrap()
+            .add_preimage(preimage)
+            .map(|d| d.to_string()))
+    }
+
+    /// wasm: `spendBuilder.sign(privateKey)` -> bool
+    pub fn sign(&self, signing_key: &FfiPrivateKey) -> bool {
+        self.builder.lock().unwrap().sign(&signing_key.signing_key)
+    }
+}
+
+// Note: wasm `txBuilder.spend(spendBuilder)` and `allSpends()` move
+// SpendBuilder values between handles; deferred to the UBRN integration pass
+// where object-passing conventions are settled (tracked in iris-ffi README).
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{hash_public_key, tx_engine_settings_v1_default};
+
+    #[test]
+    fn private_key_round_trip() {
+        let key_bytes =
+            hex::decode("362b4073814e43f427983a83f11efcceb6741082c18f0d64b7e47340ba4485ba")
+                .unwrap();
+        let key = FfiPrivateKey::from_bytes(key_bytes).unwrap();
+        assert_eq!(key.backend_kind(), "bytes");
+        assert_eq!(
+            hash_public_key(key.public_key()).unwrap(),
+            "AyzPiJoqcqmdZdjxZ9aGLnVsbYcCphidHERKBWVXyKhNqTirshTmicG"
+        );
+    }
+
+    #[test]
+    fn tx_builder_constructs_with_default_settings() {
+        let settings = tx_engine_settings_v1_default().unwrap();
+        let builder = FfiTxBuilder::new(settings).unwrap();
+        // An empty builder reports a fee (min fee floor applies on calc)
+        let _ = builder.cur_fee();
+        let built = builder.build().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&built).unwrap();
+        assert!(parsed.is_object() || parsed.is_array());
+    }
+
+    #[test]
+    fn tx_builder_rejects_invalid_settings() {
+        assert!(FfiTxBuilder::new("not json".into()).is_err());
+    }
+}

--- a/crates/iris-grpc-proto/Cargo.toml
+++ b/crates/iris-grpc-proto/Cargo.toml
@@ -26,7 +26,7 @@ tsify = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tonic = { version = "0.12", features = ["transport"] }
+tonic = { version = "0.12", features = ["transport", "tls", "tls-webpki-roots"] }
 
 [dev-dependencies]
 iris-crypto = { workspace = true }


### PR DESCRIPTION
New crates/iris-ffi for the iris-mobile (consumed via uniffi-bindgen-react-native; see iris-mobile docs/MOBILE_STRATEGY.md §3):

- Mirrors the iris-wasm surface actually used by the extension/mobile TS layer (~30 functions + PrivateKey/TxBuilder/SpendBuilder/GrpcClient objects). Complex types cross as JSON strings — the workspace tsify is in JSON mode, so JS sees byte-identical shapes to the wasm boundary.
- GrpcClient implements gRPC-web unary over HTTPS (reqwest + rustls), matching the protocol rpc.nockbox.org actually speaks; framing and trailer parsing unit-tested. Plain-gRPC remains possible later via the existing tonic client without changing the FFI surface.
- 17 unit tests pin the same golden vectors as iris-crypto's tests and iris-mobile's jest suite (the cross-runtime parity gate), including the atom<->belts round-trip that is broken in published iris-wasm 0.2.0.

Workspace tests: 71 passing. Deferred items documented in the README (TxBuilder.spend/allSpends, private-api, pagination).

