### PR TITLE
chore(deps): update bytes to 1.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,9 +237,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"


### PR DESCRIPTION
## Summary

- Update the workspace lockfile from `bytes` 1.10.1 to 1.11.1.
- Remediate [RUSTSEC-2026-0007 / CVE-2026-25541](https://rustsec.org/advisories/RUSTSEC-2026-0007.html), an integer overflow in `BytesMut::reserve` that can lead to memory corruption when release-build overflow wraps.

## Scope and release impact

This PR updates the Rust source lockfile only. Existing published `@nockbox/iris-wasm@0.2.0` artifacts were compiled before this change and are not patched by merging this PR. A follow-up patch release of `@nockbox/iris-wasm` and downstream SDK/extension dependency updates are required before the production remediation is complete.

## Validation

- Format Check
- Clippy
- Tests
- WASM Build
- no_std Build

All checks are green on this PR.
