### PR TITLE
chore(release): prepare iris-wasm 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "iris-crypto"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "argon2",
  "arrayvec",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "iris-grpc-proto"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bip39",
  "glob",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "iris-nockchain-types"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bip39",
  "bs58",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "iris-wasm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bip39",
  "console_error_panic_hook",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "iris-ztd"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "iris-ztd-derive"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,35 +11,35 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [workspace.dependencies.iris-ztd]
 path = "crates/iris-ztd"
-version = "0.2.0"
+version = "0.2.1"
 default-features = false
 
 [workspace.dependencies.iris-ztd-derive]
 path = "crates/iris-ztd-derive"
-version = "0.2.0"
+version = "0.2.1"
 
 [workspace.dependencies.iris-crypto]
 path = "crates/iris-crypto"
-version = "0.2.0"
+version = "0.2.1"
 default-features = false
 
 
 [workspace.dependencies.iris-nockchain-types]
 path = "crates/iris-nockchain-types"
-version = "0.2.0"
+version = "0.2.1"
 
 [workspace.dependencies.iris-wasm]
 path = "crates/iris-wasm"
-version = "0.2.0"
+version = "0.2.1"
 
 [workspace.dependencies.iris-grpc-proto]
 path = "crates/iris-grpc-proto"
-version = "0.2.0"
+version = "0.2.1"
 
 # Commonly used deps for wasm bindings generation
 [workspace.dependencies.tsify]

--- a/crates/iris-nockchain-types/src/tx_engine/builder.rs
+++ b/crates/iris-nockchain-types/src/tx_engine/builder.rs
@@ -1125,6 +1125,68 @@ mod tests {
     }
 
     #[test]
+    fn test_signing_preserves_witnessless_transaction_intent() {
+        let (private_key, _) = keys();
+        let note = Note::V1(v1::NoteV1 {
+            version: Version::V1,
+            origin_page: 13,
+            name: Name::new(
+                "2H7WHTE9dFXiGgx4J432DsCLuMovNkokfcnCGRg7utWGM9h13PgQvsH"
+                    .try_into()
+                    .unwrap(),
+                "7yMzrJjkb2Xu8uURP7YB3DFcotttR8dKDXF1tSp2wJmmXUvLM7SYzvM"
+                    .try_into()
+                    .unwrap(),
+            ),
+            note_data: NoteData::empty(),
+            assets: Nicks(4294967296),
+        });
+        let recipient = "2nEFkqYm51yfqsYgfRx72w8FF9bmWqnkJu8XqY8T7psXufjYNRxf5ME"
+            .try_into()
+            .unwrap();
+        let refund_pkh = "6psXufjYNRxffRx72w8FF9b5MYg8TEmWq2nEFkqYm51yfqsnkJu8XqX"
+            .try_into()
+            .unwrap();
+        let spend_condition: (Lock, usize) = (
+            SpendCondition(
+                [
+                    LockPrimitive::Pkh(Pkh::single(private_key.public_key().hash())),
+                    LockPrimitive::Tim(LockTim::coinbase()),
+                ]
+                .into(),
+            )
+            .into(),
+            0,
+        );
+        let settings = TxEngineSettings::v1_default();
+        let mut prepared_builder = TxBuilder::new(settings);
+        prepared_builder
+            .simple_spend_base(
+                vec![(note, Some(spend_condition))],
+                recipient,
+                Nicks(1234567),
+                refund_pkh,
+                true,
+            )
+            .unwrap()
+            .set_fee_and_balance_refund(Nicks(2850816), false, true)
+            .unwrap();
+
+        let prepared_tx = prepared_builder.build();
+        let prepared_intent = prepared_tx.spends.hash();
+        let prepared_raw = prepared_tx.to_raw_tx();
+
+        let mut signing_builder =
+            TxBuilder::from_raw_tx(RawTx::V1(prepared_raw.clone()), settings).unwrap();
+        signing_builder.sign(&private_key).validate().unwrap();
+        let signed_tx = signing_builder.build();
+        let signed_raw = signed_tx.to_raw_tx();
+
+        assert_eq!(signed_tx.spends.hash(), prepared_intent);
+        assert_ne!(signed_raw.id, prepared_raw.id);
+    }
+
+    #[test]
     fn test_fee_calcs_up() {
         let (private_key, _) = keys();
 

--- a/crates/iris-wasm/scripts/build-wasm.sh
+++ b/crates/iris-wasm/scripts/build-wasm.sh
@@ -7,6 +7,10 @@ if [ -z "${NO_PACK:-}" ]; then
     rm -rf pkg
     wasm-pack build --target web --out-dir pkg --scope nockbox
 
+    # wasm-pack only discovers license files next to the crate. Include the
+    # workspace license explicitly so the published npm artifact carries it.
+    cp ../../LICENSE pkg/LICENSE
+
     # Rename original d.ts
     if [ -f pkg/iris_wasm.d.ts ] && [ ! -f pkg/iris_wasm.d.ts.orig ]; then
         mv pkg/iris_wasm.d.ts pkg/iris_wasm.d.ts.orig


### PR DESCRIPTION
## Summary

- Prepare the workspace's patch version 0.2.1 on top of the merged #27 security update.
- Produce a reviewable `@nockbox/iris-wasm@0.2.1` artifact that contains `bytes` 1.11.1 and remediates RUSTSEC-2026-0007.
- Include the repository license in the generated npm package.
- Keep all internal Iris crate versions aligned with the repository's workspace-version convention.
- Add the raw-signing invariant test used by the wallet hardening: signing preserves the witnessless spends hash (the approved transaction intent) while the raw transaction ID legitimately changes when witness signatures are attached.

## Dependency status

#27 is merged. This branch has been rebased onto the resulting `iris-rs/main`; the #27 commit is no longer duplicated in this PR. Its remaining delta is limited to the 0.2.1 version preparation, package-license inclusion, and signing-intent invariant test.

Keep this PR in draft until the rebased head receives the planned human review. After sign-off it can be marked ready and merged.

## Validation after rebase

- Cargo format
- Full Rust workspace tests
- All-target/all-feature Clippy with warnings denied (deprecated APIs explicitly allowed by CI)
- All three no-std/alloc WASM target checks
- wasm-pack release build
- Generated guard test
- Generated TypeScript declarations
- npm dry-pack: `@nockbox/iris-wasm@0.2.1`, including `LICENSE`, README, JS, WASM, declarations, guard, and package metadata
- `cargo tree -i bytes` resolves both dependency paths to 1.11.1
- Fresh GitHub CI runs on the rebased head

## Release safety

This PR does not publish npm artifacts. After human review and merge, publication must be performed deliberately from merged `iris-rs/main`. Then iris-sdk #6 must update its exact WASM dependency and rerun its build/example/package checks before SDK 0.3.0 can be published.
